### PR TITLE
fix: add blank line after headings before list items

### DIFF
--- a/src/flowmark/formats/flowmark_markdown.py
+++ b/src/flowmark/formats/flowmark_markdown.py
@@ -186,6 +186,9 @@ class MarkdownNormalizer(Renderer):
     def render_heading(self, element: block.Heading) -> str:
         result = f"{self._prefix}{'#' * element.level} {self.render_children(element)}\n"
         self._prefix = self._second_prefix
+        # After rendering a heading, don't suppress the next item break
+        # This ensures proper spacing before list items that follow headings
+        self._suppress_item_break = False
         return result
 
     def render_setext_heading(self, element: block.SetextHeading) -> str:

--- a/tests/testdocs/testdoc.expected.auto.md
+++ b/tests/testdocs/testdoc.expected.auto.md
@@ -39,6 +39,7 @@ high-stakes decisions for those who give and *receive it*. Blah blah blah and bl
   conventions)
 
 ### A subsection with some citations
+
 - Mark P. Cussen, Investopedia, [*Introduction To Incentive Stock
   Options*](http://www.investopedia.com/articles/stocks/12/introduction-incentive-stock-options.asp),
   updated 2017.
@@ -50,6 +51,7 @@ high-stakes decisions for those who give and *receive it*. Blah blah blah and bl
   Options*](https://blog.wealthfront.com/stock-options-14-crucial-questions), 2014.
 
 ### Command Execution
+
 - `command` - Name of kash command or action to execute
 
 - `args` - Arguments as comma-separated string or individual `arg_0`, `arg_1`, etc.

--- a/tests/testdocs/testdoc.expected.cleaned.md
+++ b/tests/testdocs/testdoc.expected.cleaned.md
@@ -39,6 +39,7 @@ high-stakes decisions for those who give and *receive it*. Blah blah blah and bl
   conventions)
 
 ### A subsection with some citations
+
 - Mark P. Cussen, Investopedia, [*Introduction To Incentive Stock
   Options*](http://www.investopedia.com/articles/stocks/12/introduction-incentive-stock-options.asp),
   updated 2017.
@@ -50,6 +51,7 @@ high-stakes decisions for those who give and *receive it*. Blah blah blah and bl
   Options*](https://blog.wealthfront.com/stock-options-14-crucial-questions), 2014.
 
 ### Command Execution
+
 - `command` - Name of kash command or action to execute
 
 - `args` - Arguments as comma-separated string or individual `arg_0`, `arg_1`, etc.

--- a/tests/testdocs/testdoc.expected.plain.md
+++ b/tests/testdocs/testdoc.expected.plain.md
@@ -37,6 +37,7 @@ high-stakes decisions for those who give and *receive it*. Blah blah blah and bl
   conventions)
 
 ### A subsection with some citations
+
 - Mark P. Cussen, Investopedia, [*Introduction To Incentive Stock
   Options*](http://www.investopedia.com/articles/stocks/12/introduction-incentive-stock-options.asp),
   updated 2017.
@@ -48,6 +49,7 @@ high-stakes decisions for those who give and *receive it*. Blah blah blah and bl
   Options*](https://blog.wealthfront.com/stock-options-14-crucial-questions), 2014.
 
 ### Command Execution
+
 - `command` - Name of kash command or action to execute
 
 - `args` - Arguments as comma-separated string or individual `arg_0`, `arg_1`, etc.

--- a/tests/testdocs/testdoc.expected.semantic.md
+++ b/tests/testdocs/testdoc.expected.semantic.md
@@ -39,6 +39,7 @@ high-stakes decisions for those who give and *receive it*. Blah blah blah and bl
   conventions)
 
 ### A subsection with some citations
+
 - Mark P. Cussen, Investopedia, [*Introduction To Incentive Stock
   Options*](http://www.investopedia.com/articles/stocks/12/introduction-incentive-stock-options.asp),
   updated 2017.
@@ -50,6 +51,7 @@ high-stakes decisions for those who give and *receive it*. Blah blah blah and bl
   Options*](https://blog.wealthfront.com/stock-options-14-crucial-questions), 2014.
 
 ### Command Execution
+
 - `command` - Name of kash command or action to execute
 
 - `args` - Arguments as comma-separated string or individual `arg_0`, `arg_1`, etc.


### PR DESCRIPTION
Fixes bug where headings followed immediately by list items had no blank line separator. This improves readability and consistency with how other block elements (code blocks, quotes) are spaced.

The fix ensures that after rendering a heading, the _suppress_item_break flag is set to False, which causes the next list item to add a blank line separator. This matches the behavior of render_quote() and _render_code().

Updated all expected test outputs to reflect the correct formatting with blank lines after headings before lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)