### PR TITLE
Fix multi-line opening tags placing closing tags on own line

### DIFF
--- a/tests/testdocs/testdoc.expected.auto.md
+++ b/tests/testdocs/testdoc.expected.auto.md
@@ -1693,6 +1693,29 @@ Self-closing tags with tables:
 
 <!-- end-section -->
 
+### Issue 7: Multi-Line Opening Tags (GitHub Issue #17)
+
+When an opening tag is long enough to wrap across multiple lines, the closing tag should
+be placed on its own line to avoid triggering a Markdoc parser bug.
+
+This tag is long enough to wrap and should have its closing tag on a separate line:
+
+{% field kind="number" id="age" label="Your Age" role="user" required=true min=0 max=150
+integer=true placeholder="Enter your age" %}
+{% /field %}
+
+HTML comment version:
+
+<!-- f:field kind="number" id="score" label="Score" role="user" required=true min=0
+max=100 integer=true placeholder="Enter score" -->
+<!-- /f:field -->
+
+Short tags that fit on one line should remain together:
+
+{% field kind="string" id="name" %}{% /field %}
+
+<!-- f:field id="email" --><!-- /f:field -->
+
 ### Mixed Content Test
 
 A form with various content types:

--- a/tests/testdocs/testdoc.expected.cleaned.md
+++ b/tests/testdocs/testdoc.expected.cleaned.md
@@ -1693,6 +1693,29 @@ Self-closing tags with tables:
 
 <!-- end-section -->
 
+### Issue 7: Multi-Line Opening Tags (GitHub Issue #17)
+
+When an opening tag is long enough to wrap across multiple lines, the closing tag should
+be placed on its own line to avoid triggering a Markdoc parser bug.
+
+This tag is long enough to wrap and should have its closing tag on a separate line:
+
+{% field kind="number" id="age" label="Your Age" role="user" required=true min=0 max=150
+integer=true placeholder="Enter your age" %}
+{% /field %}
+
+HTML comment version:
+
+<!-- f:field kind="number" id="score" label="Score" role="user" required=true min=0
+max=100 integer=true placeholder="Enter score" -->
+<!-- /f:field -->
+
+Short tags that fit on one line should remain together:
+
+{% field kind="string" id="name" %}{% /field %}
+
+<!-- f:field id="email" --><!-- /f:field -->
+
 ### Mixed Content Test
 
 A form with various content types:

--- a/tests/testdocs/testdoc.expected.plain.md
+++ b/tests/testdocs/testdoc.expected.plain.md
@@ -1644,6 +1644,29 @@ Self-closing tags with tables:
 
 <!-- end-section -->
 
+### Issue 7: Multi-Line Opening Tags (GitHub Issue #17)
+
+When an opening tag is long enough to wrap across multiple lines, the closing tag should
+be placed on its own line to avoid triggering a Markdoc parser bug.
+
+This tag is long enough to wrap and should have its closing tag on a separate line:
+
+{% field kind="number" id="age" label="Your Age" role="user" required=true min=0 max=150
+integer=true placeholder="Enter your age" %}
+{% /field %}
+
+HTML comment version:
+
+<!-- f:field kind="number" id="score" label="Score" role="user" required=true min=0
+max=100 integer=true placeholder="Enter score" -->
+<!-- /f:field -->
+
+Short tags that fit on one line should remain together:
+
+{% field kind="string" id="name" %}{% /field %}
+
+<!-- f:field id="email" --><!-- /f:field -->
+
 ### Mixed Content Test
 
 A form with various content types:

--- a/tests/testdocs/testdoc.expected.semantic.md
+++ b/tests/testdocs/testdoc.expected.semantic.md
@@ -1693,6 +1693,29 @@ Self-closing tags with tables:
 
 <!-- end-section -->
 
+### Issue 7: Multi-Line Opening Tags (GitHub Issue #17)
+
+When an opening tag is long enough to wrap across multiple lines, the closing tag should
+be placed on its own line to avoid triggering a Markdoc parser bug.
+
+This tag is long enough to wrap and should have its closing tag on a separate line:
+
+{% field kind="number" id="age" label="Your Age" role="user" required=true min=0 max=150
+integer=true placeholder="Enter your age" %}
+{% /field %}
+
+HTML comment version:
+
+<!-- f:field kind="number" id="score" label="Score" role="user" required=true min=0
+max=100 integer=true placeholder="Enter score" -->
+<!-- /f:field -->
+
+Short tags that fit on one line should remain together:
+
+{% field kind="string" id="name" %}{% /field %}
+
+<!-- f:field id="email" --><!-- /f:field -->
+
 ### Mixed Content Test
 
 A form with various content types:

--- a/tests/testdocs/testdoc.orig.md
+++ b/tests/testdocs/testdoc.orig.md
@@ -1299,6 +1299,24 @@ Self-closing tags with tables:
 | X | 1 |
 <!-- end-section -->
 
+### Issue 7: Multi-Line Opening Tags (GitHub Issue #17)
+
+When an opening tag is long enough to wrap across multiple lines, the closing tag should be placed on its own line to avoid triggering a Markdoc parser bug.
+
+This tag is long enough to wrap and should have its closing tag on a separate line:
+
+{% field kind="number" id="age" label="Your Age" role="user" required=true min=0 max=150 integer=true placeholder="Enter your age" %}{% /field %}
+
+HTML comment version:
+
+<!-- f:field kind="number" id="score" label="Score" role="user" required=true min=0 max=100 integer=true placeholder="Enter score" --><!-- /f:field -->
+
+Short tags that fit on one line should remain together:
+
+{% field kind="string" id="name" %}{% /field %}
+
+<!-- f:field id="email" --><!-- /f:field -->
+
 ### Mixed Content Test
 
 A form with various content types:


### PR DESCRIPTION
## Summary

- When Flowmark wraps long Markdoc tags across multiple lines, the closing tag could end up on the same line as the opening tag's closing delimiter (`%}`), triggering a Markdoc parser bug
- This fix ensures that when an opening tag spans multiple lines, the closing tag is placed on its own line

**Before (triggers Markdoc bug):**
```markdown
{% field kind="string" id="name" label="Name" required=true
maxLength=50 %}{% /field %}
```

**After (correct):**
```markdown
{% field kind="string" id="name" label="Name" required=true
maxLength=50 %}
{% /field %}
```

## Changes

- Added `_fix_multiline_opening_tag_with_closing()` function in `tag_handling.py`
- Integrated fix into all wrapper return paths in `add_tag_newline_handling()`
- Added 4 unit tests in `test_tag_formatting.py`
- Added Issue 7 test cases in testdoc

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (160 tests)
- [x] Verified with reproduction case from issue #17

Fixes #17

🤖 Generated with [Claude Code](https://claude.ai/code)