### PR TITLE
Fix extra newline before tags on continuation lines

### DIFF
--- a/tests/testdocs/testdoc.expected.auto.md
+++ b/tests/testdocs/testdoc.expected.auto.md
@@ -1626,6 +1626,21 @@ Short tags that fit on one line should remain together:
 
 <!-- f:field id="email" --><!-- /f:field -->
 
+### Issue 8: Continuation Lines with Tags
+
+List items with tags on continuation lines should NOT have extra blank lines inserted.
+The indented tag is part of the list item content, not a separate tag block.
+
+**Phase 0 - Repository Setup:**
+
+- [ ] 0.1-0.2: Verify reference repos and initialize Bun monorepo with workspaces
+  <!-- #kg-11h2 -->
+
+- [ ] 0.3: Configure TypeScript with strict settings (tsconfig.base.json)
+  <!-- #kg-32zz -->
+
+- [ ] 0.4: Configure Biome for formatting and linting <!-- #kg-ibof -->
+
 ### Mixed Content Test
 
 A form with various content types:

--- a/tests/testdocs/testdoc.expected.cleaned.md
+++ b/tests/testdocs/testdoc.expected.cleaned.md
@@ -1626,6 +1626,21 @@ Short tags that fit on one line should remain together:
 
 <!-- f:field id="email" --><!-- /f:field -->
 
+### Issue 8: Continuation Lines with Tags
+
+List items with tags on continuation lines should NOT have extra blank lines inserted.
+The indented tag is part of the list item content, not a separate tag block.
+
+**Phase 0 - Repository Setup:**
+
+- [ ] 0.1-0.2: Verify reference repos and initialize Bun monorepo with workspaces
+  <!-- #kg-11h2 -->
+
+- [ ] 0.3: Configure TypeScript with strict settings (tsconfig.base.json)
+  <!-- #kg-32zz -->
+
+- [ ] 0.4: Configure Biome for formatting and linting <!-- #kg-ibof -->
+
 ### Mixed Content Test
 
 A form with various content types:

--- a/tests/testdocs/testdoc.expected.plain.md
+++ b/tests/testdocs/testdoc.expected.plain.md
@@ -1577,6 +1577,21 @@ Short tags that fit on one line should remain together:
 
 <!-- f:field id="email" --><!-- /f:field -->
 
+### Issue 8: Continuation Lines with Tags
+
+List items with tags on continuation lines should NOT have extra blank lines inserted.
+The indented tag is part of the list item content, not a separate tag block.
+
+**Phase 0 - Repository Setup:**
+
+- [ ] 0.1-0.2: Verify reference repos and initialize Bun monorepo with workspaces
+  <!-- #kg-11h2 -->
+
+- [ ] 0.3: Configure TypeScript with strict settings (tsconfig.base.json)
+  <!-- #kg-32zz -->
+
+- [ ] 0.4: Configure Biome for formatting and linting <!-- #kg-ibof -->
+
 ### Mixed Content Test
 
 A form with various content types:

--- a/tests/testdocs/testdoc.expected.semantic.md
+++ b/tests/testdocs/testdoc.expected.semantic.md
@@ -1626,6 +1626,21 @@ Short tags that fit on one line should remain together:
 
 <!-- f:field id="email" --><!-- /f:field -->
 
+### Issue 8: Continuation Lines with Tags
+
+List items with tags on continuation lines should NOT have extra blank lines inserted.
+The indented tag is part of the list item content, not a separate tag block.
+
+**Phase 0 - Repository Setup:**
+
+- [ ] 0.1-0.2: Verify reference repos and initialize Bun monorepo with workspaces
+  <!-- #kg-11h2 -->
+
+- [ ] 0.3: Configure TypeScript with strict settings (tsconfig.base.json)
+  <!-- #kg-32zz -->
+
+- [ ] 0.4: Configure Biome for formatting and linting <!-- #kg-ibof -->
+
 ### Mixed Content Test
 
 A form with various content types:

--- a/tests/testdocs/testdoc.orig.md
+++ b/tests/testdocs/testdoc.orig.md
@@ -1317,6 +1317,20 @@ Short tags that fit on one line should remain together:
 
 <!-- f:field id="email" --><!-- /f:field -->
 
+### Issue 8: Continuation Lines with Tags
+
+List items with tags on continuation lines should NOT have extra blank lines inserted.
+The indented tag is part of the list item content, not a separate tag block.
+
+**Phase 0 - Repository Setup:**
+
+- [ ] 0.1-0.2: Verify reference repos and initialize Bun monorepo with workspaces <!-- #kg-11h2 -->
+
+- [ ] 0.3: Configure TypeScript with strict settings (tsconfig.base.json)
+  <!-- #kg-32zz -->
+
+- [ ] 0.4: Configure Biome for formatting and linting <!-- #kg-ibof -->
+
 ### Mixed Content Test
 
 A form with various content types:


### PR DESCRIPTION
## Summary

Fixed a bug where HTML comment tags on indented continuation lines (e.g., `<!-- #kg-32zz -->` after a list item) incorrectly received an extra blank line before them.

### Changes

- **`src/flowmark/linewrapping/tag_handling.py`:**
  - Modified `_is_tag_only_line()` to return `False` for indented lines, since indented tags are continuations of previous content (like list items), not standalone tag blocks
  - Added `_is_unindented_tag_line()` helper function for segment boundary detection
  - Updated segment creation and rejoin logic in `add_tag_newline_handling()` to use the new helper

- **`tests/test_tag_formatting.py`:**
  - Added `test_list_item_with_tag_on_continuation_line` regression test

- **`tests/testdocs/testdoc.orig.md`:**
  - Added "Issue 8: Continuation Lines with Tags" example

## Automated Validation

- [x] All 177 tests pass (`uv run pytest`)
- [x] New regression test `test_list_item_with_tag_on_continuation_line` specifically validates the fix
- [x] All 79 tag formatting and wrapping tests pass

## Manual Validation

To verify the fix manually:

1. Run flowmark on the following input:
   ```md
   - [ ] 0.3: Configure TypeScript with strict settings (tsconfig.base.json)
     <!-- #kg-32zz -->
   ```

2. Verify the output does NOT have an extra blank line before the tag:
   ```md
   - [ ] 0.3: Configure TypeScript with strict settings (tsconfig.base.json)
     <!-- #kg-32zz -->
   ```

   **Before fix (incorrect):**
   ```md
   - [ ] 0.3: Configure TypeScript with strict settings (tsconfig.base.json)

     <!-- #kg-32zz -->
   ```

https://claude.ai/code/session_01FGZjXWoJ2UBMrJm6KCo3za