### PR TITLE
Fix strikethrough bug: literal tildes incorrectly parsed as strikethrough

### DIFF
--- a/src/flowmark/formats/flowmark_markdown.py
+++ b/src/flowmark/formats/flowmark_markdown.py
@@ -109,11 +109,12 @@ class CustomStrikethrough(gfm_elements.Strikethrough):
     - Non-greedy `+?` for correct minimal matching
     """
 
-    pattern = re.compile(r"(?<!~)(~{1,2})(?!\s)([^~]+?)(?<!\s)\1(?!~)")
-    priority = 5
-    parse_children = True
-    parse_group = 2
+    pattern: re.Pattern[str] = re.compile(r"(?<!~)(~{1,2})(?!\s)([^~]+?)(?<!\s)\1(?!~)")
+    priority: int = 5
+    parse_children: bool = True
+    parse_group: int = 2
 
+    @override
     @classmethod
     def get_type(cls, snake_case: bool = False) -> str:
         # Ensure renderer dispatch uses "strikethrough" not "custom_strikethrough".

--- a/tests/test_strikethrough.py
+++ b/tests/test_strikethrough.py
@@ -1,0 +1,100 @@
+"""Test strikethrough and tilde handling.
+
+Tests that flowmark correctly distinguishes between:
+- Actual GFM strikethrough: ~~text~~ or ~text~
+- Literal tildes used as "approximately": ~60 seconds, ~130 words
+"""
+
+from flowmark.formats.flowmark_markdown import flowmark_markdown
+from flowmark.linewrapping.markdown_filling import fill_markdown
+
+
+def test_literal_tildes_before_numbers():
+    """Tildes before numbers (meaning 'approximately') should be preserved as literal."""
+    md = flowmark_markdown()
+
+    result = md("Target: ~60 seconds, ~130 words total\n")
+    assert result == "Target: ~60 seconds, ~130 words total\n"
+
+
+def test_literal_tildes_not_converted_to_double():
+    """The bug: ~60 seconds, ~130 should NOT become ~~60 seconds, ~~130."""
+    result = fill_markdown("Target: ~60 seconds, ~130 words total")
+    assert "~~" not in result
+    assert result.strip() == "Target: ~60 seconds, ~130 words total"
+
+
+def test_double_tilde_strikethrough():
+    """Standard ~~strikethrough~~ should be preserved."""
+    md = flowmark_markdown()
+
+    result = md("This is ~~strikethrough~~ text\n")
+    assert result == "This is ~~strikethrough~~ text\n"
+
+
+def test_single_tilde_strikethrough():
+    """Single-tilde ~strikethrough~ is valid GFM; flowmark normalizes to ~~double~~."""
+    md = flowmark_markdown()
+
+    result = md("This is ~strikethrough~ text\n")
+    assert result == "This is ~~strikethrough~~ text\n"
+
+
+def test_multiple_strikethroughs():
+    """Multiple strikethrough spans in a single line."""
+    md = flowmark_markdown()
+
+    result = md("~one~ and ~two~ items\n")
+    assert result == "~~one~~ and ~~two~~ items\n"
+
+
+def test_single_tilde_no_closer():
+    """A single tilde with no matching closer should remain literal."""
+    md = flowmark_markdown()
+
+    result = md("About ~50% of users\n")
+    assert result == "About ~50% of users\n"
+
+
+def test_tildes_with_space_before_closer():
+    """Tildes where the 'closer' is preceded by whitespace should not be strikethrough."""
+    md = flowmark_markdown()
+
+    # The second ~ is preceded by a space, so it's not right-flanking and can't close.
+    result = md("costs ~100 to ~200\n")
+    assert result == "costs ~100 to ~200\n"
+
+
+def test_tilde_space_after_opener():
+    """A tilde followed by a space is not left-flanking, so no strikethrough."""
+    md = flowmark_markdown()
+
+    result = md("~ spaced ~\n")
+    assert result == "~ spaced ~\n"
+
+
+def test_tilde_space_before_closer():
+    """A tilde preceded by a space is not right-flanking, so no strikethrough."""
+    md = flowmark_markdown()
+
+    result = md("~foo ~\n")
+    assert result == "~foo ~\n"
+
+
+def test_escaped_tildes_preserved():
+    """Backslash-escaped tildes should remain escaped."""
+    md = flowmark_markdown()
+
+    result = md("Target: \\~60 seconds, \\~130 words total\n")
+    assert result == "Target: \\~60 seconds, \\~130 words total\n"
+
+
+def test_strikethrough_in_paragraph():
+    """Strikethrough within a longer paragraph should be preserved during wrapping."""
+    result = fill_markdown(
+        "This paragraph has some ~~deleted text~~ in it and also mentions ~50 users."
+    )
+    assert "~~deleted text~~" in result
+    assert "~50 users" in result
+    # Make sure ~50 doesn't become ~~50
+    assert "~~50" not in result

--- a/tests/testdocs/testdoc.expected.auto.md
+++ b/tests/testdocs/testdoc.expected.auto.md
@@ -1665,6 +1665,45 @@ Your feedback is valuable to us.
 
 {% /form %}
 
+## Strikethrough and Tildes
+
+Standard double-tilde ~~strikethrough~~ is the most common form and should always be
+preserved. Single-tilde ~~strikethrough~~ is also valid GFM and should be normalized to
+double tildes.
+
+Here are some ~~deleted words~~ in a sentence.
+And ~~more deleted words~~ in another sentence.
+
+Multiple ~~first~~ and ~~second~~ strikethroughs on one line work fine.
+
+### Tildes as “approximately” (not strikethrough)
+
+Tildes before numbers are commonly used to mean “approximately” and must not be treated
+as strikethrough:
+
+Target: ~60 seconds, ~130 words total
+
+The meeting lasted ~45 minutes.
+We had ~20 attendees.
+The cost was ~$500.
+
+Performance improved from ~200ms to ~50ms, a ~4x improvement.
+
+There were ~1,000 users and ~500 active sessions.
+
+### Escaped tildes
+
+Escaped tildes should be preserved: \~not strikethrough\~
+
+### Edge cases
+
+A lone tilde ~ in text is fine.
+
+Tildes at the end: the value is ~~100~~.
+
+A ~~long strikethrough that spans many words in a single paragraph and may get wrapped
+across lines during formatting~~ should be handled.
+
 ## Summary
 
 All these corner cases should format consistently and predictably.

--- a/tests/testdocs/testdoc.expected.cleaned.md
+++ b/tests/testdocs/testdoc.expected.cleaned.md
@@ -1665,6 +1665,45 @@ Your feedback is valuable to us.
 
 {% /form %}
 
+## Strikethrough and Tildes
+
+Standard double-tilde ~~strikethrough~~ is the most common form and should always be
+preserved. Single-tilde ~~strikethrough~~ is also valid GFM and should be normalized to
+double tildes.
+
+Here are some ~~deleted words~~ in a sentence.
+And ~~more deleted words~~ in another sentence.
+
+Multiple ~~first~~ and ~~second~~ strikethroughs on one line work fine.
+
+### Tildes as "approximately" (not strikethrough)
+
+Tildes before numbers are commonly used to mean "approximately" and must not be treated
+as strikethrough:
+
+Target: ~60 seconds, ~130 words total
+
+The meeting lasted ~45 minutes.
+We had ~20 attendees.
+The cost was ~$500.
+
+Performance improved from ~200ms to ~50ms, a ~4x improvement.
+
+There were ~1,000 users and ~500 active sessions.
+
+### Escaped tildes
+
+Escaped tildes should be preserved: \~not strikethrough\~
+
+### Edge cases
+
+A lone tilde ~ in text is fine.
+
+Tildes at the end: the value is ~~100~~.
+
+A ~~long strikethrough that spans many words in a single paragraph and may get wrapped
+across lines during formatting~~ should be handled.
+
 ## Summary
 
 All these corner cases should format consistently and predictably.

--- a/tests/testdocs/testdoc.expected.plain.md
+++ b/tests/testdocs/testdoc.expected.plain.md
@@ -1616,6 +1616,43 @@ us.
 
 {% /form %}
 
+## Strikethrough and Tildes
+
+Standard double-tilde ~~strikethrough~~ is the most common form and should always be
+preserved. Single-tilde ~~strikethrough~~ is also valid GFM and should be normalized to
+double tildes.
+
+Here are some ~~deleted words~~ in a sentence. And ~~more deleted words~~ in another
+sentence.
+
+Multiple ~~first~~ and ~~second~~ strikethroughs on one line work fine.
+
+### Tildes as "approximately" (not strikethrough)
+
+Tildes before numbers are commonly used to mean "approximately" and must not be treated
+as strikethrough:
+
+Target: ~60 seconds, ~130 words total
+
+The meeting lasted ~45 minutes. We had ~20 attendees. The cost was ~$500.
+
+Performance improved from ~200ms to ~50ms, a ~4x improvement.
+
+There were ~1,000 users and ~500 active sessions.
+
+### Escaped tildes
+
+Escaped tildes should be preserved: \~not strikethrough\~
+
+### Edge cases
+
+A lone tilde ~ in text is fine.
+
+Tildes at the end: the value is ~~100~~.
+
+A ~~long strikethrough that spans many words in a single paragraph and may get wrapped
+across lines during formatting~~ should be handled.
+
 ## Summary
 
 All these corner cases should format consistently and predictably.

--- a/tests/testdocs/testdoc.expected.semantic.md
+++ b/tests/testdocs/testdoc.expected.semantic.md
@@ -1665,6 +1665,45 @@ Your feedback is valuable to us.
 
 {% /form %}
 
+## Strikethrough and Tildes
+
+Standard double-tilde ~~strikethrough~~ is the most common form and should always be
+preserved. Single-tilde ~~strikethrough~~ is also valid GFM and should be normalized to
+double tildes.
+
+Here are some ~~deleted words~~ in a sentence.
+And ~~more deleted words~~ in another sentence.
+
+Multiple ~~first~~ and ~~second~~ strikethroughs on one line work fine.
+
+### Tildes as "approximately" (not strikethrough)
+
+Tildes before numbers are commonly used to mean "approximately" and must not be treated
+as strikethrough:
+
+Target: ~60 seconds, ~130 words total
+
+The meeting lasted ~45 minutes.
+We had ~20 attendees.
+The cost was ~$500.
+
+Performance improved from ~200ms to ~50ms, a ~4x improvement.
+
+There were ~1,000 users and ~500 active sessions.
+
+### Escaped tildes
+
+Escaped tildes should be preserved: \~not strikethrough\~
+
+### Edge cases
+
+A lone tilde ~ in text is fine.
+
+Tildes at the end: the value is ~~100~~.
+
+A ~~long strikethrough that spans many words in a single paragraph and may get wrapped
+across lines during formatting~~ should be handled.
+
 ## Summary
 
 All these corner cases should format consistently and predictably.

--- a/tests/testdocs/testdoc.orig.md
+++ b/tests/testdocs/testdoc.orig.md
@@ -1353,6 +1353,39 @@ Your feedback is valuable to us.
 
 {% /form %}
 
+## Strikethrough and Tildes
+
+Standard double-tilde ~~strikethrough~~ is the most common form and should always be preserved.
+Single-tilde ~strikethrough~ is also valid GFM and should be normalized to double tildes.
+
+Here are some ~~deleted words~~ in a sentence. And ~more deleted words~ in another sentence.
+
+Multiple ~~first~~ and ~~second~~ strikethroughs on one line work fine.
+
+### Tildes as "approximately" (not strikethrough)
+
+Tildes before numbers are commonly used to mean "approximately" and must not be treated as strikethrough:
+
+Target: ~60 seconds, ~130 words total
+
+The meeting lasted ~45 minutes. We had ~20 attendees. The cost was ~$500.
+
+Performance improved from ~200ms to ~50ms, a ~4x improvement.
+
+There were ~1,000 users and ~500 active sessions.
+
+### Escaped tildes
+
+Escaped tildes should be preserved: \~not strikethrough\~
+
+### Edge cases
+
+A lone tilde ~ in text is fine.
+
+Tildes at the end: the value is ~100~.
+
+A ~~long strikethrough that spans many words in a single paragraph and may get wrapped across lines during formatting~~ should be handled.
+
 ## Summary
 
 


### PR DESCRIPTION
## Summary

- Fix bug where `~60 seconds, ~130 words total` was incorrectly rewritten to `~~60 seconds, ~~130 words total` (rendering as strikethrough in Markdown)
- Override marko's `Strikethrough` regex with a corrected pattern that implements GFM spec flanking delimiter rules: opening tilde must not be followed by whitespace, closing tilde must not be preceded by whitespace
- Add 11 new test cases covering literal tildes, valid strikethrough, escaped tildes, and mixed usage

## Test plan

- [x] All 184 existing tests pass with no regressions
- [x] New strikethrough tests verify the specific bug case (`~60 seconds, ~130 words total` preserved as-is)
- [ ] Verify `~~strikethrough~~` still renders correctly when processed by flowmark
- [ ] Verify `~single tilde strikethrough~` is normalized to `~~double~~`
- [ ] Verify escaped tildes (`\~60`) pass through unchanged
- [ ] Manually test with a document containing mixed tilde usage (approximate numbers + actual strikethrough)

https://claude.ai/code/session_015RkkoG8hgYoDkYU43uhZNA