### PR TITLE
Fix smart quoting in tables, strikethrough, and across inline elements

### DIFF
--- a/docs/project/specs/active/plan-2026-02-14-fix-smart-quoting-containers.md
+++ b/docs/project/specs/active/plan-2026-02-14-fix-smart-quoting-containers.md
@@ -1,0 +1,158 @@
+# Bugfix Spec: Smart Quoting Not Applied in Tables, Blockquote Inline Spans
+
+## Purpose
+
+Fix smart quote conversion so it works correctly inside all container types (tables,
+strikethrough) and when quotes span across inline elements (code spans, emphasis, strong
+emphasis, links) within a paragraph or other inline scope.
+
+## Background
+
+The `flowmark` smart quoting feature converts straight ASCII quotes (`"`, `'`) to
+typographic/oriented quotes (\u201c \u201d, \u2018 \u2019) and apostrophes (\u2019).
+This is implemented via AST tree traversal in `doc_transforms.py`, which walks through
+`ContainerElement` types and applies `smart_quotes()` to each `RawText` node
+independently.
+
+Two issues have been identified where smart quotes fail to convert when expected.
+
+## Bug Template
+
+1. **In what scenarios does this bug apply?**
+
+   - Quotes inside GFM table cells are never converted
+   - Quotes inside strikethrough text are never converted
+   - Quotes that span across inline elements (e.g., opening `"` before a code span and
+     closing `"` after it) within any container type are not converted
+
+2. **What is the current behavior?**
+
+   - Table cell text: `| "Hello" |` stays as straight quotes
+   - Strikethrough text: `~~"Hello"~~` stays as straight quotes
+   - Cross-inline quotes in blockquotes:
+     `> "First, ... \`command\`."` stays as straight quotes because the opening and
+     closing `"` are in different `RawText` nodes (separated by the `CodeSpan`)
+
+3. **What is the desired behavior?**
+
+   - Table cell text: `| "Hello" |` \u2192 `| \u201cHello\u201d |`
+   - Strikethrough text: `~~"Hello"~~` \u2192 `~~\u201cHello\u201d~~`
+   - Cross-inline quotes: `> "First, ... \`command\`."` \u2192
+     `> \u201cFirst, ... \`command\`.\u201d`
+   - Code spans, fenced code, and other code content must NEVER be modified
+   - Template tag content must NEVER be modified
+
+4. **Is it reproducible?**
+
+   Yes. Minimal reproductions:
+
+   ```python
+   # Issue 1: Tables
+   fill_markdown('| "Hello" |\n| --- |\n', smartquotes=True)
+   # Returns: '| "Hello" |\n| --- |\n'  (unchanged - BUG)
+   # Expected: '| \u201cHello\u201d |\n| --- |\n'
+
+   # Issue 2: Cross-inline quotes
+   fill_markdown('**Bold:** "Start `code` end."\n', smartquotes=True)
+   # Returns: '**Bold:** "Start `code` end."\n'  (unchanged - BUG)
+   # Expected: '**Bold:** \u201cStart `code` end.\u201d\n'
+   ```
+
+5. **Could this bug appear in other situations?**
+
+   Yes. Any inline element (emphasis, strong emphasis, links, images, strikethrough)
+   that interrupts a quoted span would trigger issue 2. Issue 1 also affects
+   strikethrough content.
+
+6. **Should this be a complete, more systematic fix or a faster, lower-risk patch?**
+
+   Complete systematic fix. The root cause is architectural:
+   - Issue 1: `ContainerElement` tuple missing table/strikethrough types
+   - Issue 2: Smart quotes applied per-`RawText`-node instead of per-inline-scope
+
+7. **Should we make a deployment plan?**
+
+   No special deployment needed. Standard release.
+
+## Stage 1: Root Cause Analysis
+
+### Issue 1: Missing Container Types
+
+`ContainerElement` in `doc_transforms.py:10-21` does not include:
+- `gfm_elements.Table`
+- `gfm_elements.TableRow`
+- `gfm_elements.TableCell`
+- `gfm_elements.Strikethrough`
+
+The `transform_tree()` function only recurses into `ContainerElement` types. Since
+tables and strikethrough are not listed, their children are never visited, and `RawText`
+nodes inside them are never processed.
+
+### Issue 2: Per-Node Processing
+
+`rewrite_text_content()` in `doc_transforms.py:97-125` applies the rewrite function to
+each `RawText` node independently. When quotes span across inline elements (e.g.,
+`"text \`code\` more text."`), the opening and closing `"` are in different `RawText`
+nodes. The `QUOTE_PATTERN` regex in `smartquotes.py` needs to see both quotes in the
+same string to match them as a pair.
+
+## Stage 2: Fix Design
+
+### Approach
+
+1. **Add missing types to `ContainerElement`**: Add `gfm_elements.Table`,
+   `gfm_elements.TableRow`, `gfm_elements.TableCell`, and `gfm_elements.Strikethrough`
+   so the tree walker visits their children.
+
+2. **Cross-inline rewriting**: Create a new function `rewrite_text_across_inlines()` that:
+   a. Walks the tree looking for "inline scope" nodes (Paragraph, Heading, TableCell)
+   b. For each scope, collects all inline content into segments, tracking which are
+      from `RawText` nodes (mutable) vs other nodes (immutable context)
+   c. Concatenates all segments into a composite string
+   d. Applies `smart_quotes()` to the composite string
+   e. Maps changes back only to `RawText` segments (since smart quotes is
+      length-preserving, this is a simple positional mapping)
+
+3. **Key invariant**: `smart_quotes()` is length-preserving (each ASCII quote character
+   maps to exactly one Unicode character), so the positional mapping from composite text
+   back to individual `RawText` nodes is exact.
+
+### Safety Guarantees
+
+- `CodeSpan` content is collected for context but marked immutable \u2014 never modified
+- `FencedCode`/`CodeBlock` are not traversed at all (not in `ContainerElement`)
+- Template tags are protected by `smart_quotes()` itself (splits on `TEMPLATE_TAG_PATTERN`)
+- Code-like patterns (`x="foo"`) aren't matched by `QUOTE_PATTERN` (no whitespace before quote)
+
+### Files to Modify
+
+- `src/flowmark/transforms/doc_transforms.py` \u2014 Add container types, add cross-inline
+  rewriting function
+- `src/flowmark/linewrapping/markdown_filling.py` \u2014 Use new function for smart quotes
+- `tests/test_smartquotes.py` \u2014 Add unit tests for new scenarios
+- `tests/testdocs/testdoc.orig.md` \u2014 Add table/cross-inline test cases
+- `tests/testdocs/testdoc.expected.auto.md` \u2014 Add expected smart-quoted output
+
+## Stage 3: Implementation (TDD)
+
+### Phase 1: Add Container Types + Cross-Inline Rewriting
+
+- [ ] Write failing tests for table smart quoting
+- [ ] Write failing tests for strikethrough smart quoting
+- [ ] Write failing tests for cross-inline quote spanning
+- [ ] Add missing types to `ContainerElement`
+- [ ] Implement `_collect_inline_segments()` helper
+- [ ] Implement `rewrite_text_across_inlines()` function
+- [ ] Update `fill_markdown()` to use new function for smart quotes
+- [ ] Verify all tests pass
+- [ ] Update reference test documents
+
+### Open Questions
+
+- None at this time
+
+## Assumptions
+
+- Smart quotes conversion is always length-preserving (verified by code inspection)
+- `SetextHeading` is converted to `Heading` during parsing and doesn't need separate
+  handling in `InlineScope`

--- a/docs/project/specs/active/plan-2026-02-14-fix-smart-quoting-containers.md
+++ b/docs/project/specs/active/plan-2026-02-14-fix-smart-quoting-containers.md
@@ -137,19 +137,23 @@ same string to match them as a pair.
 
 ### Phase 1: Add Container Types + Cross-Inline Rewriting
 
-- [ ] Write failing tests for table smart quoting
-- [ ] Write failing tests for strikethrough smart quoting
-- [ ] Write failing tests for cross-inline quote spanning
-- [ ] Add missing types to `ContainerElement`
-- [ ] Implement `_collect_inline_segments()` helper
-- [ ] Implement `rewrite_text_across_inlines()` function
-- [ ] Update `fill_markdown()` to use new function for smart quotes
-- [ ] Verify all tests pass
-- [ ] Update reference test documents
+- [x] Write failing tests for table smart quoting
+- [x] Write failing tests for strikethrough smart quoting
+- [x] Write failing tests for cross-inline quote spanning
+- [x] Add missing types to `ContainerElement`
+- [x] Implement `_collect_inline_segments()` helper
+- [x] Implement `rewrite_text_across_inlines()` function
+- [x] Update `fill_markdown()` to use new function for smart quotes
+- [x] Verify all tests pass (202/202)
+- [x] Update reference test documents
+
+### Status
+
+**Complete.** All tasks done, all 202 tests passing.
 
 ### Open Questions
 
-- None at this time
+- None
 
 ## Assumptions
 

--- a/docs/project/specs/active/valid-2026-02-14-fix-smart-quoting-containers.md
+++ b/docs/project/specs/active/valid-2026-02-14-fix-smart-quoting-containers.md
@@ -1,0 +1,106 @@
+# Feature Validation: Fix Smart Quoting in Containers and Across Inline Elements
+
+## Purpose
+
+This is a validation spec for the smart quoting bugfix, listing automated testing
+performed and remaining manual validation needed.
+
+**Feature Plan:**
+[plan-2026-02-14-fix-smart-quoting-containers.md](plan-2026-02-14-fix-smart-quoting-containers.md)
+
+## Automated Validation (Testing Performed)
+
+### Unit Testing
+
+14 new integration-level tests were added to `tests/test_smartquotes.py` covering all
+affected scenarios. All 202 project tests pass.
+
+**Table cell tests (Issue 1 \u2014 missing container types):**
+
+- `test_smart_quotes_in_table_cells` \u2014 Basic double quotes inside table cells
+- `test_smart_quotes_apostrophes_in_table_cells` \u2014 Apostrophes/contractions in cells
+- `test_smart_quotes_in_table_preserve_code_spans` \u2014 Code spans inside table cells are
+  NOT modified while prose quotes in the same row ARE converted
+- `test_smart_quotes_in_table_with_bold` \u2014 Quotes in cells containing bold text
+- `test_smart_quotes_complex_table` \u2014 The exact table from the bug report (prose quotes
+  converted, code span quotes preserved)
+
+**Strikethrough tests (Issue 1):**
+
+- `test_smart_quotes_in_strikethrough` \u2014 Quotes and apostrophes inside `~~text~~`
+
+**Cross-inline element tests (Issue 2 \u2014 quotes spanning inline elements):**
+
+- `test_smart_quotes_spanning_code_span` \u2014 `"text \`code\` text."` in a paragraph
+- `test_smart_quotes_spanning_code_span_in_blockquote` \u2014 Same, inside a blockquote
+- `test_smart_quotes_spanning_emphasis` \u2014 `"text *emphasis* text."`
+- `test_smart_quotes_spanning_strong_emphasis` \u2014 `"text **bold** text."`
+- `test_smart_quotes_spanning_link` \u2014 `"text [link](url) text."`
+- `test_smart_quotes_not_modifying_code_content` \u2014 Code span containing quotes
+  (`\`x="value"\``) is NEVER modified
+- `test_smart_quotes_apostrophe_spanning_code_span` \u2014 Apostrophes around code spans
+- `test_smart_quotes_blockquote_multiline_with_code_span` \u2014 The exact blockquote from
+  the bug report (multi-line, with bold, code span, and apostrophes)
+
+**Safety / no-false-positives tests (pre-existing, all still pass):**
+
+- `test_technical_content_unchanged` \u2014 `function("param")`, `array['key']`, etc.
+- `test_complex_cases_unchanged` \u2014 Nested quotes, doubled quotes, code-like patterns
+- `test_patterns_left_unchanged` \u2014 `x="foo"`, escaped quotes, etc.
+- All 17 template tag tests in `test_tag_formatting.py` still pass
+
+### Integration and End-to-End Testing
+
+**Reference document tests (`test_ref_docs.py`):**
+
+- The reference test document (`testdoc.orig.md`) was updated with a new
+  "Smart Quoting in Containers" section containing:
+  - Table cells with quotes and code spans
+  - Blockquote with quotes spanning code spans
+  - Strikethrough with quotes
+  - Quotes spanning emphasis and links
+- All four expected output variants (plain, semantic, cleaned, auto) were regenerated
+  and verified
+- The auto variant correctly shows smart quotes in all new container contexts
+
+**Changes to expected reference output (`testdoc.expected.auto.md`):**
+
+The only changes to previously-expected output are 5 lines where quotes spanning across
+`[link](url)` elements are now correctly converted. These were previously left as straight
+quotes because the old per-node approach couldn't see across inline boundaries. The new
+output is correct.
+
+### Manual Testing Needed
+
+1. **Spot-check the CLI** on the two examples from the bug report to confirm correct
+   output visually:
+
+   ```bash
+   echo '> **Tell the user:** "First, I'\''ll make sure Markform is installed.
+   > Markform is a CLI tool for creating structured forms that agents can fill via tool
+   > calls. I'\''ll install it globally so we can use the `markform` command."' | flowmark --auto
+   ```
+
+   Expected: outer `"..."` converted to \u201c\u2026\u201d, apostrophes in `I'll` converted, code
+   span `\`markform\`` preserved.
+
+   ```bash
+   echo '| User Says | You (the Agent) Run |
+   | --- | --- |
+   | **Issues/Beads** |  |
+   | "There'\''s a bug where ..." | `tbd create "..." --type=bug` |
+   | "Create a task/feature for ..." | `tbd create "..." --type=task` or `--type=feature` |' | flowmark --auto
+   ```
+
+   Expected: prose quotes in first column converted to smart quotes, code span quotes in
+   second column preserved exactly.
+
+2. **Run on a real-world document** containing tables with prose quotes and blockquotes
+   with code spans to confirm no unexpected conversions occur.
+
+3. **Review the reference test diff** in `testdoc.expected.auto.md` to confirm the 5
+   changed lines (quotes spanning links) are correct improvements, not regressions.
+
+## Open Questions
+
+None.

--- a/src/flowmark/linewrapping/markdown_filling.py
+++ b/src/flowmark/linewrapping/markdown_filling.py
@@ -24,7 +24,7 @@ from flowmark.linewrapping.sentence_split_regex import split_sentences_regex
 from flowmark.linewrapping.tag_handling import preprocess_tag_block_spacing
 from flowmark.linewrapping.text_filling import DEFAULT_WRAP_WIDTH
 from flowmark.transforms.doc_cleanups import doc_cleanups
-from flowmark.transforms.doc_transforms import rewrite_text_content
+from flowmark.transforms.doc_transforms import rewrite_text_across_inlines, rewrite_text_content
 from flowmark.typography.ellipses import ellipses as apply_ellipses
 from flowmark.typography.smartquotes import smart_quotes
 
@@ -95,7 +95,7 @@ def fill_markdown(
     if cleanups:
         doc_cleanups(document)
     if smartquotes:
-        rewrite_text_content(document, smart_quotes, coalesce_lines=True)
+        rewrite_text_across_inlines(document, smart_quotes)
     if ellipses:
         rewrite_text_content(document, apply_ellipses, coalesce_lines=True)
     result = marko.render(document)

--- a/src/flowmark/transforms/doc_transforms.py
+++ b/src/flowmark/transforms/doc_transforms.py
@@ -167,20 +167,19 @@ def _collect_inline_segments(
     elif isinstance(element, inline.InlineHTML):
         assert isinstance(element.children, str)
         segments.append((element.children, None))
-    elif hasattr(element, "children") and isinstance(element.children, list):
+    elif hasattr(element, "children") and isinstance(element.children, list):  # pyright: ignore[reportAttributeAccessIssue]
         # Recursive container (Emphasis, StrongEmphasis, Link, Strikethrough, etc.)
-        for child in element.children:
+        children: list[Element] = element.children  # pyright: ignore[reportAttributeAccessIssue]
+        for child in children:
             segments.extend(_collect_inline_segments(child))
-    elif hasattr(element, "children") and isinstance(element.children, str):
+    elif hasattr(element, "children") and isinstance(element.children, str):  # pyright: ignore[reportAttributeAccessIssue]
         # Any other element with string content — include for context.
-        segments.append((element.children, None))
+        segments.append((element.children, None))  # pyright: ignore[reportAttributeAccessIssue]
 
     return segments
 
 
-def rewrite_text_across_inlines(
-    doc: Document, rewrite_func: Callable[[str], str]
-) -> None:
+def rewrite_text_across_inlines(doc: Document, rewrite_func: Callable[[str], str]) -> None:
     """
     Apply a length-preserving rewrite function across all inline elements within
     each inline scope (Paragraph, Heading, TableCell).

--- a/src/flowmark/transforms/doc_transforms.py
+++ b/src/flowmark/transforms/doc_transforms.py
@@ -167,14 +167,14 @@ def _collect_inline_segments(
     elif isinstance(element, inline.InlineHTML):
         assert isinstance(element.children, str)
         segments.append((element.children, None))
-    elif hasattr(element, "children") and isinstance(element.children, list):  # pyright: ignore[reportAttributeAccessIssue]
+    elif hasattr(element, "children") and isinstance(element.children, list):  # pyright: ignore
         # Recursive container (Emphasis, StrongEmphasis, Link, Strikethrough, etc.)
-        children: list[Element] = element.children  # pyright: ignore[reportAttributeAccessIssue]
+        children: list[Element] = element.children  # pyright: ignore
         for child in children:
             segments.extend(_collect_inline_segments(child))
-    elif hasattr(element, "children") and isinstance(element.children, str):  # pyright: ignore[reportAttributeAccessIssue]
+    elif hasattr(element, "children") and isinstance(element.children, str):  # pyright: ignore
         # Any other element with string content — include for context.
-        segments.append((element.children, None))  # pyright: ignore[reportAttributeAccessIssue]
+        segments.append((element.children, None))  # pyright: ignore
 
     return segments
 

--- a/tests/test_smartquotes.py
+++ b/tests/test_smartquotes.py
@@ -308,8 +308,14 @@ def test_smart_quotes_complex_table():
     )
     result = fill_markdown(text, smartquotes=True)
     # Prose quotes should be converted
-    assert "\u201cThere\u2019s a bug where \u2026\u201d" in result or "\u201cThere\u2019s a bug where ...\u201d" in result
-    assert "\u201cCreate a task/feature for \u2026\u201d" in result or "\u201cCreate a task/feature for ...\u201d" in result
+    assert (
+        "\u201cThere\u2019s a bug where \u2026\u201d" in result
+        or "\u201cThere\u2019s a bug where ...\u201d" in result
+    )
+    assert (
+        "\u201cCreate a task/feature for \u2026\u201d" in result
+        or "\u201cCreate a task/feature for ...\u201d" in result
+    )
     # Code spans should be unchanged
     assert '`tbd create "..." --type=bug`' in result
     assert '`tbd create "..." --type=task`' in result
@@ -318,7 +324,7 @@ def test_smart_quotes_complex_table():
 def test_smart_quotes_blockquote_multiline_with_code_span():
     """Test the specific blockquote from the bug report."""
     text = (
-        '> **Tell the user:** "First, I\'ll make sure Markform is installed.\n'
+        "> **Tell the user:** \"First, I'll make sure Markform is installed.\n"
         "> Markform is a CLI tool for creating structured forms that agents can fill via tool\n"
         "> calls. I'll install it globally so we can use the `markform` command.\"\n"
     )

--- a/tests/testdocs/testdoc.expected.auto.md
+++ b/tests/testdocs/testdoc.expected.auto.md
@@ -253,10 +253,10 @@ advantages:
     Google to find it. It will also help with our search and web page snippet features,
     since the mouseovers on the links will be better quality than for those on marketing
     pages or poorly organized or out-of-date official websites.
-    - Example: "The [Bay Area](https://en.wikipedia.org/wiki/San_Francisco_Bay_Area) in
+    - Example: “The [Bay Area](https://en.wikipedia.org/wiki/San_Francisco_Bay_Area) in
       [California](https://en.wikipedia.org/wiki/California) is home to both
       [Apple](https://en.wikipedia.org/wiki/Apple_Inc.) and
-      [Google](https://en.wikipedia.org/wiki/Google)."
+      [Google](https://en.wikipedia.org/wiki/Google).”
 
 A lot has changed in the last decade.
 We’re currently in a
@@ -838,14 +838,14 @@ on …
 *blah blah*
 
 The same is true for links.
-"The [Bay Area](https://en.wikipedia.org/wiki/San_Francisco_Bay_Area) in
+“The [Bay Area](https://en.wikipedia.org/wiki/San_Francisco_Bay_Area) in
 [California](https://en.wikipedia.org/wiki/California) is home to both
 [Apple](https://en.wikipedia.org/wiki/Apple_Inc.) and
-[Google](https://en.wikipedia.org/wiki/Google)." "The
+[Google](https://en.wikipedia.org/wiki/Google).” “The
 [Bay Area](https://en.wikipedia.org/wiki/San_Francisco_Bay_Area) in
 [California](https://en.wikipedia.org/wiki/California) is home to both
 [Apple](https://en.wikipedia.org/wiki/Apple_Inc.) and
-[Google](https://en.wikipedia.org/wiki/Google)." (The
+[Google](https://en.wikipedia.org/wiki/Google).” (The
 [Bay Area](https://en.wikipedia.org/wiki/San_Francisco_Bay_Area) in
 [California](https://en.wikipedia.org/wiki/California) is home to both
 [Apple](https://en.wikipedia.org/wiki/Apple_Inc.) and
@@ -1704,6 +1704,30 @@ Tildes at the end: the value is ~~100~~.
 
 A ~~long strikethrough that spans many words in a single paragraph and may get wrapped
 across lines during formatting~~ should be handled.
+
+## Smart Quoting in Containers
+
+This section tests smart quoting in various container types.
+
+### Table Cells with Quotes
+
+| Description | Command |
+| --- | --- |
+| “There’s a bug where …” | `tbd create "..." --type=bug` |
+| “Create a task” | `tbd create "..." --type=task` or `--type=feature` |
+
+### Blockquote with Quotes Spanning Code Spans
+
+> **Tell the user:** “First, I’ll make sure the `markform` command is installed.”
+
+### Strikethrough with Quotes
+
+Here is ~~“deleted” and don’t~~ some text.
+
+### Quotes Spanning Emphasis and Links
+
+He said “this is *really* important.”
+She read “the [documentation](https://example.com) first.”
 
 ## Summary
 

--- a/tests/testdocs/testdoc.expected.cleaned.md
+++ b/tests/testdocs/testdoc.expected.cleaned.md
@@ -1705,6 +1705,30 @@ Tildes at the end: the value is ~~100~~.
 A ~~long strikethrough that spans many words in a single paragraph and may get wrapped
 across lines during formatting~~ should be handled.
 
+## Smart Quoting in Containers
+
+This section tests smart quoting in various container types.
+
+### Table Cells with Quotes
+
+| Description | Command |
+| --- | --- |
+| "There's a bug where ..." | `tbd create "..." --type=bug` |
+| "Create a task" | `tbd create "..." --type=task` or `--type=feature` |
+
+### Blockquote with Quotes Spanning Code Spans
+
+> **Tell the user:** "First, I'll make sure the `markform` command is installed."
+
+### Strikethrough with Quotes
+
+Here is ~~"deleted" and don't~~ some text.
+
+### Quotes Spanning Emphasis and Links
+
+He said "this is *really* important."
+She read "the [documentation](https://example.com) first."
+
 ## Summary
 
 All these corner cases should format consistently and predictably.

--- a/tests/testdocs/testdoc.expected.plain.md
+++ b/tests/testdocs/testdoc.expected.plain.md
@@ -1654,6 +1654,30 @@ Tildes at the end: the value is ~~100~~.
 A ~~long strikethrough that spans many words in a single paragraph and may get wrapped
 across lines during formatting~~ should be handled.
 
+## Smart Quoting in Containers
+
+This section tests smart quoting in various container types.
+
+### Table Cells with Quotes
+
+| Description | Command |
+| --- | --- |
+| "There's a bug where ..." | `tbd create "..." --type=bug` |
+| "Create a task" | `tbd create "..." --type=task` or `--type=feature` |
+
+### Blockquote with Quotes Spanning Code Spans
+
+> **Tell the user:** "First, I'll make sure the `markform` command is installed."
+
+### Strikethrough with Quotes
+
+Here is ~~"deleted" and don't~~ some text.
+
+### Quotes Spanning Emphasis and Links
+
+He said "this is *really* important." She read "the [documentation](https://example.com)
+first."
+
 ## Summary
 
 All these corner cases should format consistently and predictably.

--- a/tests/testdocs/testdoc.expected.semantic.md
+++ b/tests/testdocs/testdoc.expected.semantic.md
@@ -1705,6 +1705,30 @@ Tildes at the end: the value is ~~100~~.
 A ~~long strikethrough that spans many words in a single paragraph and may get wrapped
 across lines during formatting~~ should be handled.
 
+## Smart Quoting in Containers
+
+This section tests smart quoting in various container types.
+
+### Table Cells with Quotes
+
+| Description | Command |
+| --- | --- |
+| "There's a bug where ..." | `tbd create "..." --type=bug` |
+| "Create a task" | `tbd create "..." --type=task` or `--type=feature` |
+
+### Blockquote with Quotes Spanning Code Spans
+
+> **Tell the user:** "First, I'll make sure the `markform` command is installed."
+
+### Strikethrough with Quotes
+
+Here is ~~"deleted" and don't~~ some text.
+
+### Quotes Spanning Emphasis and Links
+
+He said "this is *really* important."
+She read "the [documentation](https://example.com) first."
+
 ## Summary
 
 All these corner cases should format consistently and predictably.

--- a/tests/testdocs/testdoc.orig.md
+++ b/tests/testdocs/testdoc.orig.md
@@ -1387,6 +1387,29 @@ Tildes at the end: the value is ~100~.
 
 A ~~long strikethrough that spans many words in a single paragraph and may get wrapped across lines during formatting~~ should be handled.
 
+## Smart Quoting in Containers
+
+This section tests smart quoting in various container types.
+
+### Table Cells with Quotes
+
+| Description | Command |
+| --- | --- |
+| "There's a bug where ..." | `tbd create "..." --type=bug` |
+| "Create a task" | `tbd create "..." --type=task` or `--type=feature` |
+
+### Blockquote with Quotes Spanning Code Spans
+
+> **Tell the user:** "First, I'll make sure the `markform` command is installed."
+
+### Strikethrough with Quotes
+
+Here is ~~"deleted" and don't~~ some text.
+
+### Quotes Spanning Emphasis and Links
+
+He said "this is *really* important." She read "the [documentation](https://example.com) first."
+
 ## Summary
 
 


### PR DESCRIPTION
## Summary

Fixes two issues where smart quote conversion was not applied when expected:

1. **Tables and strikethrough** were not in the `ContainerElement` tuple, so the AST tree
   walker never visited their children — quotes inside table cells and strikethrough text
   were never converted.

2. **Quotes spanning inline elements** (code spans, emphasis, strong emphasis, links)
   could not be matched because the opening and closing quotes were in separate `RawText`
   nodes. The old per-node approach applied `smart_quotes()` to each `RawText`
   independently, so the regex couldn't see both quotes at once.

### Approach

- Added `Table`, `TableRow`, `TableCell`, and `Strikethrough` to `ContainerElement`
- Created `rewrite_text_across_inlines()` — a new function that concatenates all text
  within an inline scope (Paragraph, Heading, TableCell) into a composite string, applies
  `smart_quotes()`, and maps changes back only to `RawText` nodes. This works because
  `smart_quotes` is length-preserving (1 ASCII char → 1 Unicode char).
- `CodeSpan` content is collected for context (so the regex can see surrounding text) but
  marked immutable — code content is **never** modified.

### Files changed

- `src/flowmark/transforms/doc_transforms.py` — Added container types, `InlineScope`,
  `_collect_inline_segments()`, and `rewrite_text_across_inlines()`
- `src/flowmark/linewrapping/markdown_filling.py` — Use new function for smart quotes
- `tests/test_smartquotes.py` — 14 new integration tests
- `tests/testdocs/testdoc.orig.md` — New "Smart Quoting in Containers" test section
- `tests/testdocs/testdoc.expected.*.md` — Updated expected outputs

**Specs:**
- [plan-2026-02-14-fix-smart-quoting-containers.md](docs/project/specs/active/plan-2026-02-14-fix-smart-quoting-containers.md)
- [valid-2026-02-14-fix-smart-quoting-containers.md](docs/project/specs/active/valid-2026-02-14-fix-smart-quoting-containers.md)

## Manual Validation

- [ ] **Blockquote CLI test:** Run the blockquote example from the bug report through
  `flowmark --auto` and confirm outer quotes become smart quotes, apostrophes convert,
  and the `` `markform` `` code span is preserved:
  ```bash
  echo '> **Tell the user:** "First, I'\''ll make sure the `markform` command is installed."' | flowmark --auto
  ```

- [ ] **Table CLI test:** Run the table example and confirm prose quotes convert while
  code span quotes are preserved:
  ```bash
  echo '| "There'\''s a bug" | `tbd create "..." --type=bug` |
  | --- | --- |' | flowmark --auto
  ```

- [ ] **Review reference diff:** Confirm the 5 changed lines in
  `testdoc.expected.auto.md` (quotes spanning links now correctly converted) are
  improvements, not regressions.

- [ ] **Real-world document test:** Run `flowmark --auto` on a document with tables
  containing prose quotes and blockquotes with code spans to check for unexpected
  conversions.

https://claude.ai/code/session_01PP1fFFjUvkumVHcBpn4Xnc