### PR TITLE
fix: remove redundant force-include that breaks PyPI publish

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,14 +88,6 @@ bump = true
 # The source location for the package.
 packages = ["src/flowmark"]
 
-[tool.hatch.build.targets.wheel.force-include]
-# Include skills directory with SKILL.md in the package
-"src/flowmark/skills" = "flowmark/skills"
-
-[tool.hatch.build.targets.sdist.force-include]
-# Include skills directory with SKILL.md in the source distribution
-"src/flowmark/skills" = "flowmark/skills"
-
 
 # ---- Settings ----
 


### PR DESCRIPTION
## Summary

- Remove redundant `force-include` entries from `pyproject.toml` that caused the v0.6.4 publish workflow to fail with `FileNotFoundError: Forced include not found: .../src/flowmark/skills`

The `skills/` directory is already automatically included via `packages = ["src/flowmark"]` since it contains `__init__.py`. The `force-include` entries were redundant and broke the sdist→wheel build path used by the publish workflow.

## Test plan

- [x] `uv build` succeeds locally
- [x] Wheel from sdist builds correctly
- [x] Skills directory (`SKILL.md`, `__init__.py`) confirmed in built wheel
- [x] All 285 tests pass

https://claude.ai/code/session_01BaZnGPWit2L4H5ykXpTP1q