### PR TITLE
Add badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # flowmark
 
+[![Follow @ojoshe on X](https://img.shields.io/badge/follow_%40ojoshe-black?logo=x&logoColor=white)](https://x.com/ojoshe)
+[![CI](https://github.com/jlevy/flowmark/actions/workflows/ci.yml/badge.svg)](https://github.com/jlevy/flowmark/actions/workflows/ci.yml)
+[![PyPI version](https://img.shields.io/pypi/v/flowmark)](https://pypi.org/project/flowmark/)
+[![Python versions](https://img.shields.io/pypi/pyversions/flowmark)](https://pypi.org/project/flowmark/)
+[![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
+
 Flowmark is a pure Python Markdown auto-formatter designed for **better LLM workflows**,
 **clean git diffs**, and **flexible use from CLI, from IDEs, or as a library**.
 


### PR DESCRIPTION
## Summary
Added a set of informational badges to the top of the README to improve project visibility and provide quick links to key resources.

## Changes
- Added social media badge linking to X/Twitter (@ojoshe)
- Added CI workflow status badge linking to GitHub Actions
- Added PyPI version badge linking to the package on PyPI
- Added Python versions badge showing supported Python versions
- Added uv badge indicating the project uses the uv package manager

These badges are placed prominently at the top of the README, below the project title and before the main description, following common open source project conventions.

https://claude.ai/code/session_0134z4VJqBMoBsKnNMAWPP7P