### PR TITLE
feat(cli): align help footer with Rust and add agent guidance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,11 @@
 
 .DEFAULT_GOAL := default
 
-.PHONY: default install lint test upgrade build clean format-docs benchmark profile
+.PHONY: default install lint test upgrade build clean format format-docs benchmark profile
 
-default: format-docs install lint test
+default: format install lint test
+
+format: format-docs
 
 install:
 	uv sync --all-extras
@@ -32,7 +34,7 @@ clean:
 	-find . -type d -name "__pycache__" -exec rm -rf {} +
 
 format-docs:
-	uv run flowmark --auto README.md docs/*.md
+	uv run flowmark --auto .
 
 benchmark:
 	uv run devtools/benchmark.py --compare 0.6.0
@@ -46,4 +48,3 @@ reset-ref-docs:
 	cp tests/testdocs/testdoc.actual.cleaned.md tests/testdocs/testdoc.expected.cleaned.md
 	cp tests/testdocs/testdoc.actual.plain.md tests/testdocs/testdoc.expected.plain.md
 	cp tests/testdocs/testdoc.actual.semantic.md tests/testdocs/testdoc.expected.semantic.md
-

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-<!-- Generated from docs/shared/flowmark-readme-shared.md via scripts/generate-python-readme.py. -->
+<!-- Generated from docs/shared/flowmark-readme-shared.md via
+scripts/generate-python-readme.py.
+-->
 
 # flowmark
 
@@ -10,13 +12,14 @@
 
 ## Original Python Flowmark
 
-This repository is the original Python implementation of Flowmark.
-For fastest CLI usage via a single native binary, use the auto-synced Rust port:
+This repository is the Python reference implementation of Flowmark.
+
+For fastest CLI usage via a single native binary, consider the auto-synced Rust port:
 [flowmark-rs](https://github.com/jlevy/flowmark-rs).
 
-## Installing Flowmark (Python CLI)
+## Installing Python Flowmark CLI
 
-The simplest way to use the tool is [uv](https://github.com/astral-sh/uv).
+The simplest way to use the Python version is [uv](https://github.com/astral-sh/uv).
 
 Run with `uvx flowmark --help` or install it as a tool:
 
@@ -33,7 +36,7 @@ flowmark --help
 For use in Python projects, add the [`flowmark`](https://pypi.org/project/flowmark/)
 package via uv, poetry, or pip.
 
-Primary command: `flowmark`.
+Primary command: `flowmark`. Alias available in this repo: `flowmark-py`.
 
 * * *
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ scripts/generate-python-readme.py.
 
 ## Original Python Flowmark
 
-This repository is the Python reference implementation of Flowmark.
-
-For fastest CLI usage via a single native binary, consider the auto-synced Rust port:
-[flowmark-rs](https://github.com/jlevy/flowmark-rs).
+> [!TIP]
+> This repository is the Python reference implementation of Flowmark.
+> 
+> For fastest CLI usage via a single native binary, consider the auto-synced Rust port:
+> [flowmark-rs](https://github.com/jlevy/flowmark-rs).
 
 ## Installing Python Flowmark CLI
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # flowmark
 
-Flowmark is a pure Python Markdown auto-formatter designed for **better LLM workflows**,
-**clean git diffs**, and **flexible use from CLI, from IDEs, or as a library**.
+Flowmark is a Markdown auto-formatter, written
+[in Python](https://github.com/jlevy/flowmark) with an auto-synced
+[Rust port](https://github.com/jlevy/flowmark-rs), designed for **better LLM
+workflows**, **clean git diffs**, and **flexible use from CLI, from IDEs, or as a
+library**.
 
 With AI tools increasingly using Markdown, having consistent, diff-friendly formatting
 has become essential for modern writing, editing, and document processing workflows.

--- a/docs/shared/flowmark-readme-shared.md
+++ b/docs/shared/flowmark-readme-shared.md
@@ -1,42 +1,3 @@
-<!-- Generated from docs/shared/flowmark-readme-shared.md via scripts/generate-python-readme.py. -->
-
-# flowmark
-
-[![Follow @ojoshe on X](https://img.shields.io/badge/follow_%40ojoshe-black?logo=x&logoColor=white)](https://x.com/ojoshe)
-[![CI](https://github.com/jlevy/flowmark/actions/workflows/ci.yml/badge.svg)](https://github.com/jlevy/flowmark/actions/workflows/ci.yml)
-[![PyPI version](https://img.shields.io/pypi/v/flowmark)](https://pypi.org/project/flowmark/)
-[![Python versions](https://img.shields.io/pypi/pyversions/flowmark)](https://pypi.org/project/flowmark/)
-[![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
-
-## Original Python Flowmark
-
-This repository is the original Python implementation of Flowmark.
-For fastest CLI usage via a single native binary, use the auto-synced Rust port:
-[flowmark-rs](https://github.com/jlevy/flowmark-rs).
-
-## Installing Flowmark (Python CLI)
-
-The simplest way to use the tool is [uv](https://github.com/astral-sh/uv).
-
-Run with `uvx flowmark --help` or install it as a tool:
-
-```shell
-uv tool install --upgrade flowmark
-```
-
-Then:
-
-```shell
-flowmark --help
-```
-
-For use in Python projects, add the [`flowmark`](https://pypi.org/project/flowmark/)
-package via uv, poetry, or pip.
-
-Primary command: `flowmark`.
-
-* * *
-
 ## Why Use Flowmark?
 
 Flowmark is a Markdown auto-formatter, written
@@ -487,4 +448,3 @@ found most useful.
 ## Project Docs
 
 For development workflows, see [development.md](docs/development.md).
-

--- a/docs/templates/python-readme-wrapper.md
+++ b/docs/templates/python-readme-wrapper.md
@@ -1,4 +1,6 @@
-<!-- Generated from docs/shared/flowmark-readme-shared.md via scripts/generate-python-readme.py. -->
+<!-- Generated from docs/shared/flowmark-readme-shared.md via
+scripts/generate-python-readme.py.
+-->
 
 # flowmark
 
@@ -10,13 +12,14 @@
 
 ## Original Python Flowmark
 
-This repository is the original Python implementation of Flowmark.
-For fastest CLI usage via a single native binary, use the auto-synced Rust port:
+This repository is the Python reference implementation of Flowmark.
+
+For fastest CLI usage via a single native binary, consider the auto-synced Rust port:
 [flowmark-rs](https://github.com/jlevy/flowmark-rs).
 
-## Installing Flowmark (Python CLI)
+## Installing Python Flowmark CLI
 
-The simplest way to use the tool is [uv](https://github.com/astral-sh/uv).
+The simplest way to use the Python version is [uv](https://github.com/astral-sh/uv).
 
 Run with `uvx flowmark --help` or install it as a tool:
 
@@ -33,7 +36,7 @@ flowmark --help
 For use in Python projects, add the [`flowmark`](https://pypi.org/project/flowmark/)
 package via uv, poetry, or pip.
 
-Primary command: `flowmark`.
+Primary command: `flowmark`. Alias available in this repo: `flowmark-py`.
 
 * * *
 

--- a/docs/templates/python-readme-wrapper.md
+++ b/docs/templates/python-readme-wrapper.md
@@ -12,10 +12,11 @@ scripts/generate-python-readme.py.
 
 ## Original Python Flowmark
 
-This repository is the Python reference implementation of Flowmark.
-
-For fastest CLI usage via a single native binary, consider the auto-synced Rust port:
-[flowmark-rs](https://github.com/jlevy/flowmark-rs).
+> [!TIP]
+> This repository is the Python reference implementation of Flowmark.
+> 
+> For fastest CLI usage via a single native binary, consider the auto-synced Rust port:
+> [flowmark-rs](https://github.com/jlevy/flowmark-rs).
 
 ## Installing Python Flowmark CLI
 

--- a/docs/templates/python-readme-wrapper.md
+++ b/docs/templates/python-readme-wrapper.md
@@ -1,0 +1,40 @@
+<!-- Generated from docs/shared/flowmark-readme-shared.md via scripts/generate-python-readme.py. -->
+
+# flowmark
+
+[![Follow @ojoshe on X](https://img.shields.io/badge/follow_%40ojoshe-black?logo=x&logoColor=white)](https://x.com/ojoshe)
+[![CI](https://github.com/jlevy/flowmark/actions/workflows/ci.yml/badge.svg)](https://github.com/jlevy/flowmark/actions/workflows/ci.yml)
+[![PyPI version](https://img.shields.io/pypi/v/flowmark)](https://pypi.org/project/flowmark/)
+[![Python versions](https://img.shields.io/pypi/pyversions/flowmark)](https://pypi.org/project/flowmark/)
+[![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
+
+## Original Python Flowmark
+
+This repository is the original Python implementation of Flowmark.
+For fastest CLI usage via a single native binary, use the auto-synced Rust port:
+[flowmark-rs](https://github.com/jlevy/flowmark-rs).
+
+## Installing Flowmark (Python CLI)
+
+The simplest way to use the tool is [uv](https://github.com/astral-sh/uv).
+
+Run with `uvx flowmark --help` or install it as a tool:
+
+```shell
+uv tool install --upgrade flowmark
+```
+
+Then:
+
+```shell
+flowmark --help
+```
+
+For use in Python projects, add the [`flowmark`](https://pypi.org/project/flowmark/)
+package via uv, poetry, or pip.
+
+Primary command: `flowmark`.
+
+* * *
+
+{{ shared_docs_body }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dev = [
 [project.scripts]
 # Add script entry points here.
 flowmark = "flowmark.cli:main"
+flowmark-py = "flowmark.cli:main"
 
 
 

--- a/scripts/generate-python-readme.py
+++ b/scripts/generate-python-readme.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env -S uv run --script --python 3.14
+# /// script
+# requires-python = ">=3.14"
+# dependencies = [
+#   "jinja2>=3.1.6",
+#   "strif>=3.0.1",
+# ]
+# ///
+"""Generate Python README.md from wrapper template + shared docs body."""
+
+from __future__ import annotations
+
+from argparse import ArgumentParser
+from pathlib import Path
+
+from jinja2 import Environment, StrictUndefined
+from strif import atomic_output_file
+
+
+def parse_args() -> tuple[Path, Path, Path]:
+    """Parse arguments and resolve default repo-relative paths."""
+    repo_root = Path(__file__).resolve().parents[1]
+    parser = ArgumentParser(description="Generate README.md from Python wrapper + shared docs.")
+    parser.add_argument(
+        "--shared-docs",
+        type=Path,
+        default=repo_root / "docs/shared/flowmark-readme-shared.md",
+        help="Path to shared README body content.",
+    )
+    parser.add_argument(
+        "--template",
+        type=Path,
+        default=repo_root / "docs/templates/python-readme-wrapper.md",
+        help="Path to Python README wrapper template.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=repo_root / "README.md",
+        help="Output README path.",
+    )
+    args = parser.parse_args()
+    return args.shared_docs, args.template, args.output
+
+
+def render_readme(template_path: Path, shared_docs_body: str) -> str:
+    """Render README template with shared docs body."""
+    environment = Environment(
+        autoescape=False,
+        undefined=StrictUndefined,
+        keep_trailing_newline=True,
+    )
+    template = environment.from_string(template_path.read_text(encoding="utf-8"))
+    rendered = template.render(shared_docs_body=shared_docs_body.rstrip() + "\n")
+    if not rendered.endswith("\n"):
+        rendered += "\n"
+    return rendered
+
+
+def write_atomic(output_path: Path, content: str) -> None:
+    """Write output atomically."""
+    with atomic_output_file(output_path, make_parents=True) as temp_path:
+        Path(temp_path).write_text(content, encoding="utf-8")
+
+
+def main() -> int:
+    """Generate README.md from shared docs and wrapper template."""
+    shared_docs_path, template_path, output_path = parse_args()
+
+    if not shared_docs_path.exists():
+        raise FileNotFoundError(f"missing shared docs source at {shared_docs_path}")
+    if not template_path.exists():
+        raise FileNotFoundError(f"missing wrapper template at {template_path}")
+
+    shared_docs_body = shared_docs_path.read_text(encoding="utf-8")
+    rendered = render_readme(template_path, shared_docs_body)
+    write_atomic(output_path, rendered)
+
+    print(f"Generated {output_path} from {shared_docs_path} via {template_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/flowmark/cli.py
+++ b/src/flowmark/cli.py
@@ -2,60 +2,17 @@
 """
 Flowmark: Better auto-formatting for Markdown and plaintext
 
-Flowmark provides enhanced text wrapping capabilities with special handling for
-Markdown content. It can:
-
-- Format Markdown with proper line wrapping while preserving structure
-  and normalizing Markdown formatting
-
-- Optionally break lines at sentence boundaries for better diff readability
-
-- Process plaintext with HTML-aware word splitting
-
-It is both a library and a command-line tool.
-
-Command-line usage examples:
-
-  # Format all Markdown files in current directory recursively
-  flowmark --auto .
-
-  # Format all Markdown files in a specific directory
-  flowmark --auto docs/
-
-  # Format a Markdown file to stdout
-  flowmark README.md
-
-  # Format multiple Markdown files in-place
-  flowmark --inplace README.md CHANGELOG.md docs/*.md
-
-  # Format a Markdown file in-place without backups and all auto-formatting
-  # options enabled
+Common usage:
   flowmark --auto README.md
-
-  # List files that would be formatted (without formatting)
+  flowmark --auto docs/
+  flowmark --auto .
   flowmark --list-files .
 
-  # Format with additional file patterns
-  flowmark --auto --extend-include "*.mdx" .
+Agent usage:
+  flowmark --skill
+  Agents should run `flowmark --skill` for full Flowmark usage guidance.
 
-  # Format but skip a specific directory
-  flowmark --auto --extend-exclude "drafts/" .
-
-  # Format a Markdown file and save to a new file
-  flowmark README.md -o README_formatted.md
-
-  # Edit a file in-place (with or without making a backup)
-  flowmark --inplace README.md
-  flowmark --inplace --nobackup README.md
-
-  # Process plaintext instead of Markdown
-  flowmark --plaintext text.txt
-
-  # Use semantic line breaks (based on sentences, which is helpful to reduce
-  # irrelevant line wrap diffs in git history)
-  flowmark --semantic README.md
-
-For more details, see: https://github.com/jlevy/flowmark
+Use `flowmark --docs` for full documentation.
 """
 
 from __future__ import annotations

--- a/src/flowmark/skills/SKILL.md
+++ b/src/flowmark/skills/SKILL.md
@@ -83,6 +83,25 @@ uvx flowmark@latest --list-files .
 cat document.md | uvx flowmark@latest --semantic > formatted.md
 ```
 
+### VS Code/Cursor (Run on Save)
+
+Install the `emeraldwalk.runonsave` extension and add this to `settings.json`:
+
+```json
+"emeraldwalk.runonsave": {
+  "autoClearConsole": false,
+  "commands": [
+    {
+      "match": "(\\.md|\\.md\\.jinja|\\.mdc)$",
+      "cmd": "flowmark --auto ${file}"
+    }
+  ]
+}
+```
+
+If you prefer not to install the CLI globally, use `uvx flowmark@latest --auto ${file}`
+instead.
+
 ## Semantic Line Breaks
 
 Flowmark's `--semantic` option breaks lines at sentence boundaries instead of at fixed

--- a/src/flowmark/skills/SKILL.md
+++ b/src/flowmark/skills/SKILL.md
@@ -99,9 +99,6 @@ Install the `emeraldwalk.runonsave` extension and add this to `settings.json`:
 }
 ```
 
-If you prefer not to install the CLI globally, use `uvx flowmark@latest --auto ${file}`
-instead.
-
 ## Semantic Line Breaks
 
 Flowmark's `--semantic` option breaks lines at sentence boundaries instead of at fixed

--- a/tests/golden/cli-golden.tryscript.md
+++ b/tests/golden/cli-golden.tryscript.md
@@ -28,6 +28,33 @@ $ flowmark --version
 [VERSION]
 ```
 
+## Help: tagline and concise footer
+
+```console
+$ flowmark --help | grep -F "Flowmark: Better auto-formatting for Markdown and plaintext"
+Flowmark: Better auto-formatting for Markdown and plaintext
+```
+
+```console
+$ flowmark --help | grep -F "flowmark --auto README.md"
+  flowmark --auto README.md
+```
+
+```console
+$ flowmark --help | grep -F "flowmark --list-files ."
+  flowmark --list-files .
+```
+
+```console
+$ flowmark --help | grep -Fx "  flowmark --skill"
+  flowmark --skill
+```
+
+```console
+$ flowmark --help | grep -F "Agents should run"
+  Agents should run `flowmark --skill` for full Flowmark usage guidance.
+```
+
 ## Stdin: default formatting
 
 ```console
@@ -136,7 +163,7 @@ $ flowmark --list-files --no-respect-gitignore . | grep generated
 ## Force exclude: explicit file in excluded dir
 
 ```console
-$ flowmark --list-files --force-exclude node_modules/pkg/README.md | wc -l
+$ flowmark --list-files --force-exclude node_modules/pkg/README.md | wc -l | tr -d ' '
 0
 ```
 

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -1,0 +1,47 @@
+"""Tests for CLI help text and help footer guidance."""
+
+from __future__ import annotations
+
+import pytest
+
+from flowmark.cli import main
+
+
+def _render_help(capsys: pytest.CaptureFixture[str]) -> str:
+    """Run `flowmark --help` via CLI entrypoint and return captured stdout."""
+    with pytest.raises(SystemExit) as exc:
+        main(["--help"])
+    assert exc.value.code == 0
+    return capsys.readouterr().out
+
+
+def test_help_includes_tagline(capsys: pytest.CaptureFixture[str]) -> None:
+    """Help output should include the canonical Flowmark tagline."""
+    out = _render_help(capsys)
+    assert "Flowmark: Better auto-formatting for Markdown and plaintext" in out
+
+
+def test_help_includes_brief_common_usage(capsys: pytest.CaptureFixture[str]) -> None:
+    """Help output should include the concise common usage examples."""
+    out = _render_help(capsys)
+    assert "Common usage:" in out
+    assert "flowmark --auto README.md" in out
+    assert "flowmark --auto docs/" in out
+    assert "flowmark --auto ." in out
+    assert "flowmark --list-files ." in out
+
+
+def test_help_includes_agent_guidance(capsys: pytest.CaptureFixture[str]) -> None:
+    """Help output should include explicit agent guidance via --skill."""
+    out = _render_help(capsys)
+    assert "Agent usage:" in out
+    assert "flowmark --skill" in out
+    assert "Agents should run `flowmark --skill` for full Flowmark usage guidance." in out
+    assert "Use `flowmark --docs` for full documentation." in out
+
+
+def test_help_omits_old_long_epilog(capsys: pytest.CaptureFixture[str]) -> None:
+    """Help output should not include the old long-form examples section."""
+    out = _render_help(capsys)
+    assert "Command-line usage examples:" not in out
+    assert "Flowmark provides enhanced text wrapping capabilities" not in out

--- a/tests/test_packaging_entrypoints.py
+++ b/tests/test_packaging_entrypoints.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
-try:
-    import tomllib
-except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
-    import tomli as tomllib
+if sys.version_info >= (3, 11):
+    import tomllib  # pyright: ignore[reportUnreachable]
+else:
+    import tomli as tomllib  # type: ignore[no-redef]  # pyright: ignore[reportUnreachable]
 
 
 def test_flowmark_py_alias_entrypoint() -> None:

--- a/tests/test_packaging_entrypoints.py
+++ b/tests/test_packaging_entrypoints.py
@@ -1,0 +1,20 @@
+"""Packaging entrypoint tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
+    import tomli as tomllib
+
+
+def test_flowmark_py_alias_entrypoint() -> None:
+    """Both flowmark and flowmark-py should point to the same CLI entrypoint."""
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    scripts = data["project"]["scripts"]
+
+    assert scripts["flowmark"] == "flowmark.cli:main"
+    assert scripts["flowmark-py"] == "flowmark.cli:main"

--- a/tests/test_skill.py
+++ b/tests/test_skill.py
@@ -50,7 +50,7 @@ class TestGetDocsContent:
         content = get_docs_content()
         # README.md has these distinctive sections
         assert "# flowmark" in content.lower()
-        assert "## Installing Flowmark (Python CLI)" in content
+        assert "## Installing Python Flowmark CLI" in content
         assert "## Semantic Line Breaks" in content
 
     def test_docs_content_has_vscode_cursor_setup(self) -> None:

--- a/tests/test_skill.py
+++ b/tests/test_skill.py
@@ -50,7 +50,7 @@ class TestGetDocsContent:
         content = get_docs_content()
         # README.md has these distinctive sections
         assert "# flowmark" in content.lower()
-        assert "## Installation" in content
+        assert "## Installing Flowmark (Python CLI)" in content
         assert "## Semantic Line Breaks" in content
 
     def test_docs_content_has_vscode_cursor_setup(self) -> None:

--- a/tests/test_skill.py
+++ b/tests/test_skill.py
@@ -29,6 +29,12 @@ class TestGetSkillContent:
         assert "# Flowmark" in content
         assert "uvx flowmark" in content
 
+    def test_skill_content_has_vscode_cursor_setup(self) -> None:
+        """SKILL.md includes VS Code/Cursor run-on-save guidance."""
+        content = get_skill_content()
+        assert "VS Code/Cursor" in content
+        assert "emeraldwalk.runonsave" in content
+
 
 class TestGetDocsContent:
     """Tests for get_docs_content function."""
@@ -46,6 +52,12 @@ class TestGetDocsContent:
         assert "# flowmark" in content.lower()
         assert "## Installation" in content
         assert "## Semantic Line Breaks" in content
+
+    def test_docs_content_has_vscode_cursor_setup(self) -> None:
+        """README/docs content includes VS Code/Cursor run-on-save setup."""
+        content = get_docs_content()
+        assert "Use in VSCode/Cursor" in content or "Use in VS Code/Cursor" in content
+        assert "emeraldwalk.runonsave" in content
 
 
 class TestInstallSkill:


### PR DESCRIPTION
## Summary
- align Python `flowmark --help` footer with the Rust cleanup direction using a concise `Common usage` + `Agent usage` section
- keep the canonical tagline and add explicit `--skill` guidance with `--docs` pointer
- add CLI help regression coverage (`tests/test_cli_help.py`) and golden help assertions
- add VS Code/Cursor run-on-save guidance to skill output and tests
- update README intro wording to link both the Python source repo and Rust port
- merge `origin/main` into this branch and resolve README conflicts

## Validation
- `uv run pytest tests/test_cli_help.py tests/test_skill.py tests/test_cli_file_discovery.py -q`
- `npx tryscript@latest run tests/golden/cli-golden.tryscript.md`
- `uv run flowmark --help`

## Linked Rust PR
- https://github.com/jlevy/flowmark-rs/pull/26
