### PR TITLE
fix: keep reference link when label equals text (issue #45)

### DIFF
--- a/.tbd/config.yml
+++ b/.tbd/config.yml
@@ -1,5 +1,14 @@
+tbd_format: f03
+tbd_version: 0.1.12
 display:
   id_prefix: fm
+sync:
+  branch: tbd-sync
+  remote: origin
+settings:
+  auto_sync: false
+  doc_auto_sync_hours: 24
+  use_gh_cli: true
 # Documentation cache configuration.
 # files: Maps destination paths (relative to .tbd/docs/) to source locations.
 #   Sources can be:
@@ -13,34 +22,14 @@ display:
 # Auto-sync: Docs are automatically synced when stale (default: every 24 hours).
 # Configure with settings.doc_auto_sync_hours (0 = disabled).
 docs_cache:
+  lookup_path:
+    - .tbd/docs/shortcuts/system
+    - .tbd/docs/shortcuts/standard
   files:
-    guidelines/backward-compatibility-rules.md: internal:guidelines/backward-compatibility-rules.md
-    guidelines/bun-monorepo-patterns.md: internal:guidelines/bun-monorepo-patterns.md
-    guidelines/cli-agent-skill-patterns.md: internal:guidelines/cli-agent-skill-patterns.md
-    guidelines/commit-conventions.md: internal:guidelines/commit-conventions.md
-    guidelines/convex-limits-best-practices.md: internal:guidelines/convex-limits-best-practices.md
-    guidelines/convex-rules.md: internal:guidelines/convex-rules.md
-    guidelines/electron-app-development-patterns.md: internal:guidelines/electron-app-development-patterns.md
-    guidelines/error-handling-rules.md: internal:guidelines/error-handling-rules.md
-    guidelines/general-coding-rules.md: internal:guidelines/general-coding-rules.md
-    guidelines/general-comment-rules.md: internal:guidelines/general-comment-rules.md
-    guidelines/general-eng-assistant-rules.md: internal:guidelines/general-eng-assistant-rules.md
-    guidelines/general-style-rules.md: internal:guidelines/general-style-rules.md
-    guidelines/general-tdd-guidelines.md: internal:guidelines/general-tdd-guidelines.md
-    guidelines/general-testing-rules.md: internal:guidelines/general-testing-rules.md
-    guidelines/golden-testing-guidelines.md: internal:guidelines/golden-testing-guidelines.md
-    guidelines/pnpm-monorepo-patterns.md: internal:guidelines/pnpm-monorepo-patterns.md
-    guidelines/python-cli-patterns.md: internal:guidelines/python-cli-patterns.md
-    guidelines/python-modern-guidelines.md: internal:guidelines/python-modern-guidelines.md
-    guidelines/python-rules.md: internal:guidelines/python-rules.md
-    guidelines/release-notes-guidelines.md: internal:guidelines/release-notes-guidelines.md
-    guidelines/tbd-sync-troubleshooting.md: internal:guidelines/tbd-sync-troubleshooting.md
-    guidelines/typescript-cli-tool-rules.md: internal:guidelines/typescript-cli-tool-rules.md
-    guidelines/typescript-code-coverage.md: internal:guidelines/typescript-code-coverage.md
-    guidelines/typescript-rules.md: internal:guidelines/typescript-rules.md
-    guidelines/typescript-sorting-patterns.md: internal:guidelines/typescript-sorting-patterns.md
-    guidelines/typescript-yaml-handling-rules.md: internal:guidelines/typescript-yaml-handling-rules.md
-    guidelines/writing-style-guidelines.md: internal:guidelines/writing-style-guidelines.md
+    shortcuts/system/shortcut-explanation.md: internal:shortcuts/system/shortcut-explanation.md
+    shortcuts/system/skill-baseline.md: internal:shortcuts/system/skill-baseline.md
+    shortcuts/system/skill-brief.md: internal:shortcuts/system/skill-brief.md
+    shortcuts/system/skill-minimal.md: internal:shortcuts/system/skill-minimal.md
     shortcuts/standard/agent-handoff.md: internal:shortcuts/standard/agent-handoff.md
     shortcuts/standard/checkout-third-party-repo.md: internal:shortcuts/standard/checkout-third-party-repo.md
     shortcuts/standard/code-cleanup-all.md: internal:shortcuts/standard/code-cleanup-all.md
@@ -71,23 +60,35 @@ docs_cache:
     shortcuts/standard/sync-failure-recovery.md: internal:shortcuts/standard/sync-failure-recovery.md
     shortcuts/standard/update-specs-status.md: internal:shortcuts/standard/update-specs-status.md
     shortcuts/standard/welcome-user.md: internal:shortcuts/standard/welcome-user.md
-    shortcuts/system/shortcut-explanation.md: internal:shortcuts/system/shortcut-explanation.md
-    shortcuts/system/skill-baseline.md: internal:shortcuts/system/skill-baseline.md
-    shortcuts/system/skill-brief.md: internal:shortcuts/system/skill-brief.md
-    shortcuts/system/skill-minimal.md: internal:shortcuts/system/skill-minimal.md
+    guidelines/backward-compatibility-rules.md: internal:guidelines/backward-compatibility-rules.md
+    guidelines/bun-monorepo-patterns.md: internal:guidelines/bun-monorepo-patterns.md
+    guidelines/cli-agent-skill-patterns.md: internal:guidelines/cli-agent-skill-patterns.md
+    guidelines/commit-conventions.md: internal:guidelines/commit-conventions.md
+    guidelines/convex-limits-best-practices.md: internal:guidelines/convex-limits-best-practices.md
+    guidelines/convex-rules.md: internal:guidelines/convex-rules.md
+    guidelines/electron-app-development-patterns.md: internal:guidelines/electron-app-development-patterns.md
+    guidelines/error-handling-rules.md: internal:guidelines/error-handling-rules.md
+    guidelines/general-coding-rules.md: internal:guidelines/general-coding-rules.md
+    guidelines/general-comment-rules.md: internal:guidelines/general-comment-rules.md
+    guidelines/general-eng-assistant-rules.md: internal:guidelines/general-eng-assistant-rules.md
+    guidelines/general-style-rules.md: internal:guidelines/general-style-rules.md
+    guidelines/general-tdd-guidelines.md: internal:guidelines/general-tdd-guidelines.md
+    guidelines/general-testing-rules.md: internal:guidelines/general-testing-rules.md
+    guidelines/golden-testing-guidelines.md: internal:guidelines/golden-testing-guidelines.md
+    guidelines/pnpm-monorepo-patterns.md: internal:guidelines/pnpm-monorepo-patterns.md
+    guidelines/python-cli-patterns.md: internal:guidelines/python-cli-patterns.md
+    guidelines/python-modern-guidelines.md: internal:guidelines/python-modern-guidelines.md
+    guidelines/python-rules.md: internal:guidelines/python-rules.md
+    guidelines/release-notes-guidelines.md: internal:guidelines/release-notes-guidelines.md
+    guidelines/supply-chain-hardening.md: internal:guidelines/supply-chain-hardening.md
+    guidelines/tbd-sync-troubleshooting.md: internal:guidelines/tbd-sync-troubleshooting.md
+    guidelines/typescript-cli-tool-rules.md: internal:guidelines/typescript-cli-tool-rules.md
+    guidelines/typescript-code-coverage.md: internal:guidelines/typescript-code-coverage.md
+    guidelines/typescript-rules.md: internal:guidelines/typescript-rules.md
+    guidelines/typescript-sorting-patterns.md: internal:guidelines/typescript-sorting-patterns.md
+    guidelines/typescript-yaml-handling-rules.md: internal:guidelines/typescript-yaml-handling-rules.md
+    guidelines/writing-style-guidelines.md: internal:guidelines/writing-style-guidelines.md
     templates/architecture-doc.md: internal:templates/architecture-doc.md
     templates/plan-spec.md: internal:templates/plan-spec.md
     templates/qa-playbook.md: internal:templates/qa-playbook.md
     templates/research-brief.md: internal:templates/research-brief.md
-  lookup_path:
-    - .tbd/docs/shortcuts/system
-    - .tbd/docs/shortcuts/standard
-settings:
-  auto_sync: false
-  doc_auto_sync_hours: 24
-  use_gh_cli: true
-sync:
-  branch: tbd-sync
-  remote: origin
-tbd_format: f03
-tbd_version: 0.1.12

--- a/src/flowmark/formats/flowmark_markdown.py
+++ b/src/flowmark/formats/flowmark_markdown.py
@@ -553,7 +553,12 @@ class MarkdownNormalizer(Renderer):
         )
         if label is not None:
             if label == link_text:
-                return f"[{label}]"
+                # Use the collapsed reference form [label][] rather than the
+                # shortcut form [label]. A shortcut reference is fragile: it
+                # merges with a following "(...)" (becoming an inline link) or
+                # "[...]" (becoming a full/collapsed reference), silently
+                # changing or dropping links. See issue #45.
+                return f"[{label}][]"
             return f"[{link_text}][{label}]"
         title = f" {link_title}" if link_title is not None else ""
         return f"[{link_text}]({element.dest}{title})"

--- a/tests/test_reference_links.py
+++ b/tests/test_reference_links.py
@@ -1,0 +1,99 @@
+"""Test reference-style link rendering.
+
+Regression tests for https://github.com/jlevy/flowmark/issues/45
+
+marko's inline.Link element does not preserve the original reference style
+(inline, full, collapsed, or shortcut); it only stores ``dest`` and ``title``.
+flowmark reconstructs a reference link by matching the destination/title back
+to a link reference definition.
+
+When the link text equals the matched label, the link must NOT be collapsed to
+the shortcut form ``[label]``: a shortcut reference is fragile because it merges
+with a following ``(...)`` (becoming an inline link) or a following ``[...]``
+(becoming a full/collapsed reference), silently changing or dropping links.
+The collapsed reference form ``[label][]`` is used instead, which is unambiguous.
+"""
+
+import marko
+
+from flowmark.formats.flowmark_markdown import flowmark_markdown
+
+
+def _html(src: str) -> str:
+    """Render markdown to HTML with stock marko, for semantic equivalence checks."""
+    parser = marko.Markdown()
+    return parser.render(parser.parse(src)).strip()
+
+
+def test_full_reference_with_distinct_label_preserved():
+    """[text][label] with text != label stays a full reference (the 'fm' case)."""
+    md = flowmark_markdown()
+    src = "Use [flowmark][fm]\n\n[fm]: https://github.com/jlevy/flowmark\n"
+    assert md(src) == "Use [flowmark][fm]\n\n[fm]: https://github.com/jlevy/flowmark\n"
+
+
+def test_label_equals_text_not_collapsed_to_shortcut():
+    """[flowmark][flowmark] must not become a bare [flowmark] shortcut.
+
+    This is the exact case from issue #45.
+    """
+    md = flowmark_markdown()
+    src = "Use [flowmark][flowmark]\n\n[flowmark]: https://github.com/jlevy/flowmark\n"
+    result = md(src)
+    assert result == "Use [flowmark][]\n\n[flowmark]: https://github.com/jlevy/flowmark\n"
+
+
+def test_issue_45_link_survives_round_trip():
+    """The reformatted output must still parse to the same link as the input."""
+    md = flowmark_markdown()
+    src = "Use [flowmark][flowmark]\n\n[flowmark]: https://github.com/jlevy/flowmark\n"
+    result = md(src)
+    assert _html(result) == _html(src)
+    # The link is preserved, not dropped.
+    assert '<a href="https://github.com/jlevy/flowmark">flowmark</a>' in _html(result)
+
+
+def test_idempotent_on_collapsed_reference():
+    """Formatting is stable: collapsed reference output is a fixed point."""
+    md = flowmark_markdown()
+    src = "Use [flowmark][]\n\n[flowmark]: https://github.com/jlevy/flowmark\n"
+    once = md(src)
+    assert md(once) == once
+
+
+def test_shortcut_input_normalized_to_collapsed_reference():
+    """A shortcut reference [flowmark] is normalized to the explicit [flowmark][]."""
+    md = flowmark_markdown()
+    src = "Use [flowmark]\n\n[flowmark]: https://github.com/jlevy/flowmark\n"
+    assert md(src) == "Use [flowmark][]\n\n[flowmark]: https://github.com/jlevy/flowmark\n"
+
+
+def test_label_equals_text_followed_by_parens_keeps_link():
+    """[flowmark][flowmark](/path): collapsing to shortcut would steal the parens.
+
+    Shortcut [flowmark](/path) reparses as an inline link to '/path', changing the
+    destination. The collapsed form keeps the original destination.
+    """
+    md = flowmark_markdown()
+    src = "See [flowmark][flowmark](/path) end.\n\n[flowmark]: https://example.com\n"
+    result = md(src)
+    assert _html(result) == _html(src)
+    assert '<a href="https://example.com">flowmark</a>' in _html(result)
+
+
+def test_label_equals_text_followed_by_reference_keeps_both_links():
+    """[flowmark][flowmark][ref2]: collapsing to shortcut would drop the first link.
+
+    Shortcut [flowmark][ref2] reparses as one full reference (flowmark -> ref2),
+    losing the flowmark link entirely.
+    """
+    md = flowmark_markdown()
+    src = (
+        "See [flowmark][flowmark][ref2] end.\n\n"
+        "[flowmark]: https://example.com\n"
+        "[ref2]: https://example.org\n"
+    )
+    result = md(src)
+    assert _html(result) == _html(src)
+    assert '<a href="https://example.com">flowmark</a>' in _html(result)
+    assert '<a href="https://example.org">ref2</a>' in _html(result)

--- a/tests/tryscript/fixtures/content/comprehensive.md
+++ b/tests/tryscript/fixtures/content/comprehensive.md
@@ -67,7 +67,10 @@ Backslash escapes: \* not bold \* and \# not a heading.
 
 An [inline link](https://example.com) and a [reference link][ref1].
 
+A [collapsed][collapsed] reference where label equals text.
+
 [ref1]: https://example.com "Example Reference"
+[collapsed]: https://example.com/collapsed
 
 ![An image](https://example.com/image.png)
 

--- a/tests/tryscript/formatting.tryscript.md
+++ b/tests/tryscript/formatting.tryscript.md
@@ -230,6 +230,8 @@ Regular paragraph after headings.
 Tests that ALL Markdown structures are preserved through formatting.
 Asserts full output with no truncation. This test validates:
 - Reference links preserved as reference syntax (not inlined)
+- Reference links whose label equals their text use the collapsed `[label][]`
+  form, never the fragile shortcut `[label]` form (issue #45)
 - Footnote definitions stay in their original position (not moved to end)
 - Nested list spacing matches Python (no extra blank lines)
 - All other Markdown structures round-trip correctly
@@ -311,7 +313,10 @@ Backslash escapes: \* not bold \* and \# not a heading.
 
 An [inline link](https://example.com) and a [reference link][ref1].
 
+A [collapsed][] reference where label equals text.
+
 [ref1]: https://example.com "Example Reference"
+[collapsed]: https://example.com/collapsed
 
 ![An image](https://example.com/image.png)
 


### PR DESCRIPTION
## Summary

Fixes #45.

A reference-style link whose text matched its label (e.g. `[flowmark][flowmark]`) was being rendered as the bare **shortcut** form `[flowmark]`. The reporter noticed the explicit reference disappeared, while a distinct label like `[flowmark][fm]` was preserved.

### Root cause

`marko`'s `inline.Link` element does not preserve the original reference style — it only stores `dest` and `title`. `flowmark` reconstructs the reference by matching the destination back to a link reference definition (`render_link` in `flowmark_markdown.py`). When the matched label equaled the link text, it emitted the shortcut form `[label]`.

The shortcut form is **fragile**: it silently merges with adjacent syntax, which is a genuine correctness bug, not just a cosmetic change:

| Input | Old output | Reparses as |
| --- | --- | --- |
| `[flowmark][flowmark](/path)` | `[flowmark](/path)` | inline link to `/path` (**destination changed**) |
| `[flowmark][flowmark][ref2]` | `[flowmark][ref2]` | one link `flowmark → ref2` (**first link dropped**) |

### Fix

Emit the unambiguous **collapsed reference** form `[label][]` instead of the shortcut `[label]`. This keeps the link explicit and robust against following `(...)` or `[...]`.

```
Use [flowmark][flowmark]   ->   Use [flowmark][]
```

## Test plan

- [x] New `tests/test_reference_links.py` covering: the exact issue case, distinct-label preservation, shortcut-input normalization, idempotency, and the two link-breakage cases (followed by parens / by another reference) verified via HTML round-trip equivalence.
- [x] Added a label-equals-text case to the `comprehensive.md` golden fixture (F10).
- [x] `uv run pytest` — 309 passed.
- [x] `npx tryscript run tests/tryscript/*.tryscript.md` — 127 passed.
- [x] `devtools/lint.py` (ruff + typecheck) — clean.

https://claude.ai/code/session_01PdT7BMisiPQZEg8BaU2n8G

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdT7BMisiPQZEg8BaU2n8G)_