### PR TITLE
ci: align build/CI infra with simple-modern-uv template (Node 24 actions, check-only lint, frozen publish)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,13 +40,16 @@ jobs:
       # https://docs.astral.sh/uv/guides/integration/github/
 
       - name: Checkout (official GitHub action)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Important for versioning plugins:
           fetch-depth: 0
 
       - name: Install uv (official Astral action)
-        uses: astral-sh/setup-uv@v5
+        # Pinned to a full, immutable version tag. As of v8, setup-uv no longer
+        # publishes floating major/minor tags (e.g. `@v8`), so bump this exact
+        # version when updating.
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           # Update this as needed:
           version: "0.11.13"
@@ -68,7 +71,8 @@ jobs:
         run: uv sync --all-extras --frozen
 
       - name: Run linting
-        run: uv run python devtools/lint.py
+        # Check-only mode so CI fails on unformatted code instead of fixing it.
+        run: uv run python devtools/lint.py --check
 
       - name: Run tests
         run: uv run pytest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,13 +18,14 @@ jobs:
       contents: read
     steps:
       - name: Checkout (official GitHub action)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Important for versioning plugins:
           fetch-depth: 0
 
       - name: Install uv (official Astral action)
-        uses: astral-sh/setup-uv@v5
+        # Pinned to a full, immutable version tag (see note in ci.yml).
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "0.11.13"
           enable-cache: true
@@ -34,7 +35,9 @@ jobs:
         run: uv python install
 
       - name: Install all dependencies
-        run: uv sync --all-extras
+        # --frozen: install exactly from uv.lock, never re-resolving (matches ci.yml).
+        # See SUPPLY-CHAIN-SECURITY.md.
+        run: uv sync --all-extras --frozen
 
       - name: Run tests
         run: uv run pytest

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 .DEFAULT_GOAL := default
 
-.PHONY: default install lint test test-golden test-golden-coverage upgrade build clean \
+.PHONY: default install lint lint-check test test-golden test-golden-coverage upgrade build clean \
         format format-docs generate generate-readme generate-skill validate-skill \
         check-release-pin benchmark profile reset-ref-docs
 
@@ -56,6 +56,10 @@ install:
 
 lint:
 	uv run python devtools/lint.py
+
+# Check-only lint, matching CI (does not modify files).
+lint-check:
+	uv run python devtools/lint.py --check
 
 test:
 	uv run pytest

--- a/devtools/lint.py
+++ b/devtools/lint.py
@@ -1,4 +1,6 @@
+import argparse
 import subprocess
+import sys
 
 from funlog import log_calls
 from rich import get_console, reconfigure
@@ -12,13 +14,24 @@ DOC_PATHS = ["README.md"]
 reconfigure(emoji=not get_console().options.legacy_windows)  # No emojis on legacy windows.
 
 
-def main():
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run linting and formatting.")
+    # CI should not modify files: check-only mode fails on any issue instead of
+    # silently fixing it, so unformatted code can't slip through.
+    parser.add_argument("--check", action="store_true", help="Check only, without modifying files.")
+    args = parser.parse_args()
+
     rprint()
 
     errcount = 0
-    errcount += run(["codespell", "--write-changes", *SRC_PATHS, *DOC_PATHS])
-    errcount += run(["ruff", "check", "--fix", *SRC_PATHS])
-    errcount += run(["ruff", "format", *SRC_PATHS])
+    if args.check:
+        errcount += run(["codespell", *SRC_PATHS, *DOC_PATHS])
+        errcount += run(["ruff", "check", *SRC_PATHS])
+        errcount += run(["ruff", "format", "--check", *SRC_PATHS])
+    else:
+        errcount += run(["codespell", "--write-changes", *SRC_PATHS, *DOC_PATHS])
+        errcount += run(["ruff", "check", "--fix", *SRC_PATHS])
+        errcount += run(["ruff", "format", *SRC_PATHS])
     errcount += run(["basedpyright", "--stats", *SRC_PATHS])
 
     rprint()
@@ -50,4 +63,4 @@ def run(cmd: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    exit(main())
+    sys.exit(main())


### PR DESCRIPTION
## What's Changed

Adopts three already-vetted practices from the canonical [`jlevy/simple-modern-uv`](https://github.com/jlevy/simple-modern-uv) template, deferred out of the v0.7.1 patch since they're build-process only and don't affect the published package. (Comparison also confirmed flowmark is *ahead* of the template on supply-chain hardening — frozen lockfile, pinned isolated `pip-audit`, skill-pin guards, golden tests — so nothing was pulled back.)

### `fm-pp07` — Node 24-capable action versions (time-sensitive)
GitHub force-migrates Node 20 actions to Node 24 on **2026-06-02**. Bumped in both `ci.yml` and `publish.yml`:
- `actions/checkout@v4` → `@v6`
- `astral-sh/setup-uv@v5` → `@v8.1.0` (exact immutable pin — as of v8, setup-uv no longer publishes floating major tags)

### `fm-2u3b` — CI lint is now check-only
`devtools/lint.py` always auto-fixed (`codespell --write-changes`, `ruff check --fix`, `ruff format`), and CI ran it that way — so unformatted code was silently reformatted in CI and **never failed the build**. Added a `--check` mode (no mutation: `ruff format --check`, etc.) and CI now runs `lint.py --check`. Added a `lint-check` Make target and switched `exit()` → `sys.exit()`.

> This change immediately earned its keep: with `--check` enforced, CI would have caught that my own first edit to `lint.py` wasn't `ruff`-formatted — the old auto-fix CI would have masked it.

### `fm-2tp9` — frozen install in publish
`publish.yml` installed with `uv sync --all-extras` (re-resolving) while `ci.yml` uses `--frozen` per SUPPLY-CHAIN-SECURITY.md. Made publish frozen too, so the published artifact is built from the locked, vetted dependency set.

## Testing
- `make lint-check` passes (clean)
- 428 unit tests + 133 golden/tryscript tests pass
- The action-version bumps are validated by this PR's own CI run

https://claude.ai/code/session_019fwzmd9k1A9X6GtFZ5pez2

---
_Generated by [Claude Code](https://claude.ai/code/session_019fwzmd9k1A9X6GtFZ5pez2)_