### PR TITLE
skill: recommend flowmark-rs and document both packages

### DIFF
--- a/.agents/skills/flowmark/SKILL.md
+++ b/.agents/skills/flowmark/SKILL.md
@@ -23,15 +23,19 @@ flowmark --auto .      # whole tree (respects .gitignore and .flowmarkignore)
 
 Omit `--auto` to preview to stdout; pipe stdin with `-` (e.g. `cat FILE | flowmark -`).
 
-If `flowmark` is not on `PATH`, use a version-pinned runner (never `@latest`):
+Flowmark ships as two packages with identical formatting and the same `flowmark`
+command: the fast native Rust port [`flowmark-rs`](https://github.com/jlevy/flowmark-rs)
+(recommended) and the Python reference [`flowmark`](https://github.com/jlevy/flowmark).
+Prefer flowmark-rs; reach for the Python build only when you need its library API or the
+very latest patch release not yet ported to Rust.
+If `flowmark` is not on `PATH`, run it with a version-pinned runner (never `@latest`):
 
 ```bash
+# Recommended: fast native Rust port
+uvx --from flowmark-rs==0.3.0 flowmark --auto FILE
+# Python reference (library API or newest patch releases)
 uvx --from flowmark==0.7.1 flowmark --auto FILE
 ```
-
-> Prefer the `flowmark` command when it is on `PATH`. The auto-synced
-> [Rust port (flowmark-rs)](https://github.com/jlevy/flowmark-rs) is a fast native
-> binary with identical formatting; the Python version is the reference.
 
 ## When to Use It
 

--- a/.claude/skills/flowmark/SKILL.md
+++ b/.claude/skills/flowmark/SKILL.md
@@ -23,15 +23,19 @@ flowmark --auto .      # whole tree (respects .gitignore and .flowmarkignore)
 
 Omit `--auto` to preview to stdout; pipe stdin with `-` (e.g. `cat FILE | flowmark -`).
 
-If `flowmark` is not on `PATH`, use a version-pinned runner (never `@latest`):
+Flowmark ships as two packages with identical formatting and the same `flowmark` command:
+the fast native Rust port [`flowmark-rs`](https://github.com/jlevy/flowmark-rs)
+(recommended) and the Python reference [`flowmark`](https://github.com/jlevy/flowmark).
+Prefer flowmark-rs; reach for the Python build only when you need its library API or the
+very latest patch release not yet ported to Rust. If `flowmark` is not on `PATH`, run it
+with a version-pinned runner (never `@latest`):
 
 ```bash
+# Recommended: fast native Rust port
+uvx --from flowmark-rs==0.3.0 flowmark --auto FILE
+# Python reference (library API or newest patch releases)
 uvx --from flowmark==0.7.1 flowmark --auto FILE
 ```
-
-> Prefer the `flowmark` command when it is on `PATH`. The auto-synced
-> [Rust port (flowmark-rs)](https://github.com/jlevy/flowmark-rs) is a fast native
-> binary with identical formatting; the Python version is the reference.
 
 ## When to Use It
 
@@ -42,7 +46,8 @@ uvx --from flowmark==0.7.1 flowmark --auto FILE
 
 ## Full Documentation
 
-Flowmark documents itself. Use the CLI rather than reproducing details here:
+Flowmark documents itself.
+Use the CLI rather than reproducing details here:
 
 - `flowmark --help` — every flag: `--semantic`, `--smartquotes`, `--ellipses`,
   `--width`, `--check`, list spacing, and file discovery

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,8 @@ Auto-format Markdown with `flowmark` for clean, semantic git diffs.
 
 - Run `flowmark --auto <files>` on Markdown you create or edit.
 - Run `flowmark --docs` for full usage and `flowmark --skill` for the skill.
-- If `flowmark` is not on `PATH`, run `uvx --from flowmark==0.7.1 flowmark`.
+- If `flowmark` is not on `PATH`, use a pinned `uvx` runner (never `@latest`).
+- Fast Rust port (recommended): `uvx --from flowmark-rs==0.3.0 flowmark`.
+- Python build (library / newest patch): `uvx --from flowmark==0.7.1 flowmark`.
 
 <!-- END FLOWMARK INTEGRATION -->

--- a/skills/flowmark/SKILL.md
+++ b/skills/flowmark/SKILL.md
@@ -23,15 +23,19 @@ flowmark --auto .      # whole tree (respects .gitignore and .flowmarkignore)
 
 Omit `--auto` to preview to stdout; pipe stdin with `-` (e.g. `cat FILE | flowmark -`).
 
-If `flowmark` is not on `PATH`, use a version-pinned runner (never `@latest`):
+Flowmark ships as two packages with identical formatting and the same `flowmark`
+command: the fast native Rust port [`flowmark-rs`](https://github.com/jlevy/flowmark-rs)
+(recommended) and the Python reference [`flowmark`](https://github.com/jlevy/flowmark).
+Prefer flowmark-rs; reach for the Python build only when you need its library API or the
+very latest patch release not yet ported to Rust.
+If `flowmark` is not on `PATH`, run it with a version-pinned runner (never `@latest`):
 
 ```bash
+# Recommended: fast native Rust port
+uvx --from flowmark-rs==0.3.0 flowmark --auto FILE
+# Python reference (library API or newest patch releases)
 uvx --from flowmark==0.7.1 flowmark --auto FILE
 ```
-
-> Prefer the `flowmark` command when it is on `PATH`. The auto-synced
-> [Rust port (flowmark-rs)](https://github.com/jlevy/flowmark-rs) is a fast native
-> binary with identical formatting; the Python version is the reference.
 
 ## When to Use It
 

--- a/src/flowmark/skill.py
+++ b/src/flowmark/skill.py
@@ -29,25 +29,36 @@ FLOWMARK_FORMAT = "f02"
 # CROSS-IMPLEMENTATION PORTING CONTRACT (read before porting to flowmark-rs)
 #
 # This file is auto-ported to the Rust implementation (github.com/jlevy/flowmark-rs)
-# by an LLM following the rust-porting playbook. The version pin below and the
-# `uvx --from <pkg>==<X.Y.Z>` bootstrap line in SKILL.md are PER-IMPLEMENTATION and
-# MUST NOT be copied verbatim across the port:
+# by an LLM following the rust-porting playbook. The SKILL.md recommends the fast Rust
+# port by default and offers the Python build as the reference fallback, so it pins BOTH
+# packages via two placeholders:
 #
-#   - Python flowmark   pins  `uvx --from flowmark==<this package's version>`
-#   - Rust   flowmark-rs pins  `uvx --from flowmark-rs==<flowmark-rs's own version>`
+#   - `__FLOWMARK_RS_VERSION__` -> the flowmark-rs (Rust) pin
+#   - `__FLOWMARK_VERSION__`    -> the flowmark   (Python) pin
 #
 # `flowmark` and `flowmark-rs` are separate PyPI packages with INDEPENDENT, DIFFERENTLY
-# NUMBERED release histories (the Python version is the reference and is often ahead).
-# When porting, substitute BOTH the package name (`flowmark` -> `flowmark-rs`) AND the
-# version (use flowmark-rs's own current release, NOT this file's number). Each pin must
-# always be a real, installable release of *that* package. Pinning the Rust skill to a
-# Python version number (or vice versa) is a bug: the `uvx --from` would resolve to the
+# NUMBERED release histories (the Python version is the reference and is often ahead;
+# flowmark-rs tracks it but is numbered on its own and is sometimes a release behind).
+#
+# Each implementation pins its OWN package dynamically (from its installed build) and the
+# SIBLING package from a hard-coded discovery constant. The two roles SWAP across the
+# port, but the authored SKILL.md is IDENTICAL — only the substitution sources differ, so
+# the port stays mechanical:
+#
+#   - Python flowmark   : `__FLOWMARK_VERSION__` <- flowmark_version() (own, dynamic),
+#                         `__FLOWMARK_RS_VERSION__` <- FLOWMARK_RS_DISCOVERY_VERSION (sibling).
+#   - Rust   flowmark-rs : `__FLOWMARK_RS_VERSION__` <- its own installed version,
+#                         `__FLOWMARK_VERSION__` <- a sibling flowmark (Python) constant.
+#
+# Each pin must always be a real, installable release of *that* package. Pinning one
+# package to the other's version number is a bug: the `uvx --from` would resolve to the
 # wrong package's release or fail outright.
 # ─────────────────────────────────────────────────────────────────────────────
 
-# Placeholder in the authored SKILL.md, replaced by `compose_skill` with a concrete
-# version pin for the local-first runner fallback (see SKILL.md).
-_VERSION_PLACEHOLDER = "__FLOWMARK_VERSION__"
+# Placeholders in the authored SKILL.md, replaced by `compose_skill` with concrete
+# version pins for the local-first runner fallbacks (see SKILL.md).
+_VERSION_PLACEHOLDER = "__FLOWMARK_VERSION__"  # this package (flowmark, Python)
+_RS_VERSION_PLACEHOLDER = "__FLOWMARK_RS_VERSION__"  # sibling Rust port (flowmark-rs)
 
 # Concrete released-version pin baked into the committed repo-root discovery copy
 # (`skills/flowmark/SKILL.md`), the artifact `npx skills add jlevy/flowmark` and
@@ -59,6 +70,17 @@ _VERSION_PLACEHOLDER = "__FLOWMARK_VERSION__"
 # Rust port: this becomes flowmark-rs's own release version — see the porting
 # contract above.
 DISCOVERY_VERSION = "0.7.1"
+
+# Recommended pin for the fast Rust port (github.com/jlevy/flowmark-rs) — the default the
+# skill suggests. flowmark and flowmark-rs are SEPARATE PyPI packages with independent
+# numbering (flowmark-rs tracks the Python reference but is versioned on its own and is
+# sometimes a release behind), so this is NOT the Python DISCOVERY_VERSION — it is
+# flowmark-rs's own latest published release. Bump it when flowmark-rs releases. Must be a
+# real, PyPI-installable release (guarded by tests) so the recommended
+# `uvx --from flowmark-rs==<X.Y.Z> flowmark` bootstrap actually resolves.
+# Rust port: roles swap — the port pins flowmark-rs dynamically (its own build) and keeps
+# a sibling flowmark (Python) discovery constant here instead. See the porting contract.
+FLOWMARK_RS_DISCOVERY_VERSION = "0.3.0"
 
 
 def get_skill_content() -> str:
@@ -124,14 +146,19 @@ def compose_skill(version: str | None = None) -> str:
     """
     Render the SKILL.md template into a final skill document.
 
-    `version` is substituted into the pinned-runner fallback. Pass an explicit string
-    (e.g. `DISCOVERY_VERSION` for the committed discovery copy) for a stable, drift-free
-    artifact; pass `None` to pin to the installed flowmark version (used when installing
-    into an agent on a user's machine). Deterministic: same inputs always yield identical
-    output.
+    `version` is the Python `flowmark` pin substituted into the runner fallback. Pass an
+    explicit string (e.g. `DISCOVERY_VERSION` for the committed discovery copy) for a
+    stable, drift-free artifact; pass `None` to pin to the installed flowmark version
+    (used when installing into an agent on a user's machine). The recommended Rust-port
+    pin always comes from `FLOWMARK_RS_DISCOVERY_VERSION`. Deterministic: same inputs
+    always yield identical output.
     """
     pin = flowmark_version() if version is None else version
-    return get_skill_content().replace(_VERSION_PLACEHOLDER, pin)
+    return (
+        get_skill_content()
+        .replace(_VERSION_PLACEHOLDER, pin)
+        .replace(_RS_VERSION_PLACEHOLDER, FLOWMARK_RS_DISCOVERY_VERSION)
+    )
 
 
 def get_docs_content() -> str:
@@ -245,7 +272,9 @@ def agents_md_block(version: str | None = None) -> str:
         "\n"
         "- Run `flowmark --auto <files>` on Markdown you create or edit.\n"
         "- Run `flowmark --docs` for full usage and `flowmark --skill` for the skill.\n"
-        f"- If `flowmark` is not on `PATH`, run `uvx --from flowmark=={pin} flowmark`.\n"
+        "- If `flowmark` is not on `PATH`, use a pinned `uvx` runner (never `@latest`).\n"
+        f"- Fast Rust port (recommended): `uvx --from flowmark-rs=={FLOWMARK_RS_DISCOVERY_VERSION} flowmark`.\n"
+        f"- Python build (library / newest patch): `uvx --from flowmark=={pin} flowmark`.\n"
         "\n"
         f"{AGENTS_END_MARKER}"
     )

--- a/src/flowmark/skills/SKILL.md
+++ b/src/flowmark/skills/SKILL.md
@@ -21,15 +21,19 @@ flowmark --auto .      # whole tree (respects .gitignore and .flowmarkignore)
 
 Omit `--auto` to preview to stdout; pipe stdin with `-` (e.g. `cat FILE | flowmark -`).
 
-If `flowmark` is not on `PATH`, use a version-pinned runner (never `@latest`):
+Flowmark ships as two packages with identical formatting and the same `flowmark`
+command: the fast native Rust port [`flowmark-rs`](https://github.com/jlevy/flowmark-rs)
+(recommended) and the Python reference [`flowmark`](https://github.com/jlevy/flowmark).
+Prefer flowmark-rs; reach for the Python build only when you need its library API or the
+very latest patch release not yet ported to Rust.
+If `flowmark` is not on `PATH`, run it with a version-pinned runner (never `@latest`):
 
 ```bash
+# Recommended: fast native Rust port
+uvx --from flowmark-rs==__FLOWMARK_RS_VERSION__ flowmark --auto FILE
+# Python reference (library API or newest patch releases)
 uvx --from flowmark==__FLOWMARK_VERSION__ flowmark --auto FILE
 ```
-
-> Prefer the `flowmark` command when it is on `PATH`. The auto-synced
-> [Rust port (flowmark-rs)](https://github.com/jlevy/flowmark-rs) is a fast native
-> binary with identical formatting; the Python version is the reference.
 
 ## When to Use It
 

--- a/tests/test_skill.py
+++ b/tests/test_skill.py
@@ -10,6 +10,7 @@ from flowmark.skill import (
     AGENTS_BEGIN_PREFIX,
     AGENTS_END_MARKER,
     DISCOVERY_VERSION,
+    FLOWMARK_RS_DISCOVERY_VERSION,
     SURFACE_CLAUDE,
     SURFACE_PORTABLE,
     agents_md_block,
@@ -53,6 +54,21 @@ class TestComposeSkill:
         rendered = compose_skill("1.2.3")
         assert "flowmark==1.2.3" in rendered
         assert "__FLOWMARK_VERSION__" not in rendered
+
+    def test_compose_substitutes_both_package_pins(self) -> None:
+        """Both the Python and the recommended Rust-port placeholders are filled in."""
+        rendered = compose_skill("1.2.3")
+        assert "__FLOWMARK_RS_VERSION__" not in rendered
+        assert f"flowmark-rs=={FLOWMARK_RS_DISCOVERY_VERSION}" in rendered
+        # The Python pin tracks the passed version; the Rust pin is its own constant.
+        assert "flowmark==1.2.3" in rendered
+
+    def test_compose_recommends_rust_offers_python(self) -> None:
+        """The skill names both packages and links each one."""
+        rendered = compose_skill("1.2.3")
+        assert "github.com/jlevy/flowmark-rs" in rendered
+        assert "github.com/jlevy/flowmark)" in rendered
+        assert "uvx --from flowmark-rs==" in rendered
 
     def test_compose_default_pins_installed_version(self) -> None:
         rendered = compose_skill()

--- a/tests/test_skill_artifacts.py
+++ b/tests/test_skill_artifacts.py
@@ -7,7 +7,13 @@ from pathlib import Path
 import pytest
 
 from flowmark import reformat_text
-from flowmark.skill import DISCOVERY_VERSION, compose_skill, discovery_skill_text
+from flowmark.skill import (
+    DISCOVERY_VERSION,
+    FLOWMARK_RS_DISCOVERY_VERSION,
+    compose_skill,
+    discovery_skill_text,
+    is_pypi_release,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DISCOVERY_COPY = REPO_ROOT / "skills" / "flowmark" / "SKILL.md"
@@ -27,9 +33,21 @@ _PINNED_ARTIFACTS = [
     REPO_ROOT / "AGENTS.md",
 ]
 
+# Skill surfaces that also carry a recommended Rust-port `flowmark-rs==` pin (the README
+# references flowmark-rs without an exact pin, so it is excluded here).
+_RS_PINNED_ARTIFACTS = [
+    DISCOVERY_COPY,
+    REPO_ROOT / ".agents" / "skills" / "flowmark" / "SKILL.md",
+    REPO_ROOT / ".claude" / "skills" / "flowmark" / "SKILL.md",
+    REPO_ROOT / "AGENTS.md",
+]
+
 # A concrete `flowmark==<version>` pin (digit-led), ignoring intentionally-generic
-# `flowmark==<X.Y.Z>` / `flowmark==<version>` placeholder examples in prose.
+# `flowmark==<X.Y.Z>` / `flowmark==<version>` placeholder examples in prose. The trailing
+# `(?!-)` keeps it from matching the `flowmark` prefix of a `flowmark-rs==` pin.
 _CONCRETE_PIN_RE = re.compile(r"flowmark==(\d[^\s`)\"']*)")
+# A concrete `flowmark-rs==<version>` pin (the recommended fast Rust port).
+_CONCRETE_RS_PIN_RE = re.compile(r"flowmark-rs==(\d[^\s`)\"']*)")
 
 
 def test_discovery_copy_matches_generator() -> None:
@@ -61,16 +79,42 @@ def test_shipped_artifacts_pin_discovery_version(artifact: Path) -> None:
     )
 
 
+@pytest.mark.parametrize("artifact", _RS_PINNED_ARTIFACTS, ids=lambda p: p.name)
+def test_shipped_artifacts_pin_rs_discovery_version(artifact: Path) -> None:
+    """Every `flowmark-rs==` pin in a skill surface equals FLOWMARK_RS_DISCOVERY_VERSION.
+
+    The Rust port is the recommended default; its pin is a separate source of truth from
+    the Python DISCOVERY_VERSION (the packages are numbered independently), so this guards
+    against a stale or mismatched Rust pin slipping into one surface.
+    """
+    text = artifact.read_text(encoding="utf-8")
+    pins = _CONCRETE_RS_PIN_RE.findall(text)
+    assert pins, f"{artifact.name} has no concrete flowmark-rs== pin to check"
+    stale = sorted({p for p in pins if p != FLOWMARK_RS_DISCOVERY_VERSION})
+    assert not stale, (
+        f"{artifact.name} pins flowmark-rs {stale} but FLOWMARK_RS_DISCOVERY_VERSION is "
+        f"{FLOWMARK_RS_DISCOVERY_VERSION!r}; bump it and re-run `make format`"
+    )
+
+
+def test_rs_discovery_version_is_resolvable() -> None:
+    """The recommended Rust-port pin must be a real, PyPI-installable release."""
+    assert is_pypi_release(FLOWMARK_RS_DISCOVERY_VERSION)
+
+
 @pytest.mark.parametrize("artifact", _PINNED_ARTIFACTS, ids=lambda p: p.name)
 def test_shipped_artifacts_never_use_at_latest(artifact: Path) -> None:
-    """Shipped runner examples must pin a version, never the unpinned `flowmark@latest`.
+    """Shipped runner examples must pin a version, never an unpinned `@latest`.
 
     Mentions warning *against* `@latest` are fine; an actual `uvx flowmark@latest`
-    invocation is not (it silently drifts and defeats the supply-chain pin).
+    invocation is not (it silently drifts and defeats the supply-chain pin). The same
+    holds for the recommended Rust port, `flowmark-rs`.
     """
     text = artifact.read_text(encoding="utf-8")
     assert "uvx flowmark@latest" not in text
     assert "uvx --from flowmark@latest" not in text
+    assert "uvx flowmark-rs@latest" not in text
+    assert "uvx --from flowmark-rs@latest" not in text
 
 
 def test_discovery_copy_has_resolvable_version_pin() -> None:
@@ -82,7 +126,9 @@ def test_discovery_copy_has_resolvable_version_pin() -> None:
     the README.
     """
     text = DISCOVERY_COPY.read_text(encoding="utf-8")
-    assert "__FLOWMARK_VERSION__" not in text  # template never escaped past compose
+    # Neither placeholder may survive past compose.
+    assert "__FLOWMARK_VERSION__" not in text
+    assert "__FLOWMARK_RS_VERSION__" not in text
     assert "flowmark==<version>" not in text  # not a literal placeholder
     pin = re.search(r"flowmark==([^\s`)\"']+)", text)
     assert pin is not None, "discovery copy missing a flowmark== version pin"
@@ -91,6 +137,22 @@ def test_discovery_copy_has_resolvable_version_pin() -> None:
         f"discovery copy pin {pin_value!r} is a dev/local version, not PyPI-installable; "
         "bump DISCOVERY_VERSION to a real release and re-run `make format`"
     )
+    rs_pin = re.search(r"flowmark-rs==([^\s`)\"']+)", text)
+    assert rs_pin is not None, "discovery copy missing a flowmark-rs== version pin"
+    rs_value = rs_pin.group(1)
+    assert ".dev" not in rs_value and "+" not in rs_value, (
+        f"discovery copy Rust pin {rs_value!r} is a dev/local version, not PyPI-installable"
+    )
+
+
+def test_discovery_copy_references_both_packages() -> None:
+    """The skill recommends the Rust port and offers the Python build, so the discovery
+    copy must name and link both packages."""
+    text = DISCOVERY_COPY.read_text(encoding="utf-8")
+    assert "github.com/jlevy/flowmark-rs" in text
+    assert "github.com/jlevy/flowmark)" in text  # the Python package link
+    assert "uvx --from flowmark-rs==" in text
+    assert "uvx --from flowmark==" in text
 
 
 def test_skill_frontmatter_is_valid() -> None:


### PR DESCRIPTION
## Summary

The skill and installed docs now reference **both** flowmark implementations and recommend the fast Rust port by default: `flowmark-rs` (recommended) and the Python reference `flowmark` (for the library API or the newest patch releases not yet ported to Rust). Both invoke the same `flowmark` command, so the two pinned bootstrap lines differ only by `--from <pkg>==<ver>`.

The design is set up so the **Rust port maps over mechanically** when the skill is ported to flowmark-rs, and the testing maps over with it.

## Changes

**Skill content (`src/flowmark/skills/SKILL.md` → all surfaces):**
- The fallback section now presents both packages, recommends `flowmark-rs`, and notes when to choose Python flowmark (library API / latest patch). Two pinned runners:
  ```bash
  # Recommended: fast native Rust port
  uvx --from flowmark-rs==0.3.0 flowmark --auto FILE
  # Python reference (library API or newest patch releases)
  uvx --from flowmark==0.7.1 flowmark --auto FILE
  ```
- The `AGENTS.md` block gained the same two-runner recommendation (short lines, stays flowmark-stable).

**Portable two-placeholder design (`src/flowmark/skill.py`):**
- The authored SKILL.md uses two placeholders — `__FLOWMARK_RS_VERSION__` and `__FLOWMARK_VERSION__`. Each implementation pins its **own** package dynamically and the **sibling** package from a discovery constant; the roles swap on the port but the authored template is **identical**, so porting is mechanical (no package rename in prose).
- Added `FLOWMARK_RS_DISCOVERY_VERSION = "0.3.0"` — the recommended Rust pin, a source of truth independent of the Python `DISCOVERY_VERSION` (the two packages are numbered separately; flowmark-rs 0.3.0 tracks flowmark-py 0.7.0).
- Rewrote the cross-implementation porting contract to document the symmetric, swap-on-port structure.

**Test coverage that maps over (`tests/test_skill*.py`):**
- Every shipped `flowmark-rs==` pin must equal `FLOWMARK_RS_DISCOVERY_VERSION`; the pin must be PyPI-resolvable; no `flowmark-rs@latest`; the discovery copy must reference and link both packages; both placeholders must be substituted. These mirror the existing Python-pin guards, so the Rust port inherits the same suite.

## Test Plan

- [x] `make lint` → clean.
- [x] `make test` → **133 golden** + pytest suite pass; the skill test files grew from 65 → 73 tests, all green.
- [x] New guards verified by name: `test_compose_substitutes_both_package_pins`, `test_compose_recommends_rust_offers_python`, `test_shipped_artifacts_pin_rs_discovery_version` (×4 surfaces), `test_rs_discovery_version_is_resolvable`, `test_discovery_copy_references_both_packages`.
- [x] All four skill surfaces + `AGENTS.md` regenerated via `make generate` and in sync; `AGENTS.md` block stays unchanged under `flowmark --auto`.
- [x] **End-to-end smoke test:** both pinned bootstrap commands run and produce **identical output** —
  ```
  uvx --from flowmark-rs==0.3.0 flowmark smoke.md
  uvx --from flowmark==0.7.1   flowmark smoke.md   # → identical
  ```
- **Edge cases considered:**
  - `flowmark==` pin regex does not match inside `flowmark-rs==`, so the existing Python-pin guards stay correct.
  - Dev/editable checkouts still fall back to `DISCOVERY_VERSION` for the Python pin; the Rust pin is always the constant.
  - flowmark-rs's binary is invoked as `flowmark` (verified), so the shared `flowmark` command in the skill is correct for both packages.

## Related Beads

- Follows the SKILL.md slim-down (PR #57, merged).

https://claude.ai/code/session_01KC2RdyGySfZcvQZxjcwQhY

---
_Generated by [Claude Code](https://claude.ai/code/session_01KC2RdyGySfZcvQZxjcwQhY)_