### PR TITLE
skill: bump DISCOVERY_VERSION to v0.7.2

### DIFF
--- a/.agents/skills/flowmark/SKILL.md
+++ b/.agents/skills/flowmark/SKILL.md
@@ -34,7 +34,7 @@ If `flowmark` is not on `PATH`, run it with a version-pinned runner (never `@lat
 # Recommended: fast native Rust port
 uvx --from flowmark-rs==0.3.0 flowmark --auto FILE
 # Python reference (library API or newest patch releases)
-uvx --from flowmark==0.7.1 flowmark --auto FILE
+uvx --from flowmark==0.7.2 flowmark --auto FILE
 ```
 
 ## When to Use It

--- a/.claude/skills/flowmark/SKILL.md
+++ b/.claude/skills/flowmark/SKILL.md
@@ -23,18 +23,18 @@ flowmark --auto .      # whole tree (respects .gitignore and .flowmarkignore)
 
 Omit `--auto` to preview to stdout; pipe stdin with `-` (e.g. `cat FILE | flowmark -`).
 
-Flowmark ships as two packages with identical formatting and the same `flowmark` command:
-the fast native Rust port [`flowmark-rs`](https://github.com/jlevy/flowmark-rs)
+Flowmark ships as two packages with identical formatting and the same `flowmark`
+command: the fast native Rust port [`flowmark-rs`](https://github.com/jlevy/flowmark-rs)
 (recommended) and the Python reference [`flowmark`](https://github.com/jlevy/flowmark).
 Prefer flowmark-rs; reach for the Python build only when you need its library API or the
-very latest patch release not yet ported to Rust. If `flowmark` is not on `PATH`, run it
-with a version-pinned runner (never `@latest`):
+very latest patch release not yet ported to Rust.
+If `flowmark` is not on `PATH`, run it with a version-pinned runner (never `@latest`):
 
 ```bash
 # Recommended: fast native Rust port
 uvx --from flowmark-rs==0.3.0 flowmark --auto FILE
 # Python reference (library API or newest patch releases)
-uvx --from flowmark==0.7.1 flowmark --auto FILE
+uvx --from flowmark==0.7.2 flowmark --auto FILE
 ```
 
 ## When to Use It

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,6 @@ Auto-format Markdown with `flowmark` for clean, semantic git diffs.
 - Run `flowmark --docs` for full usage and `flowmark --skill` for the skill.
 - If `flowmark` is not on `PATH`, use a pinned `uvx` runner (never `@latest`).
 - Fast Rust port (recommended): `uvx --from flowmark-rs==0.3.0 flowmark`.
-- Python build (library / newest patch): `uvx --from flowmark==0.7.1 flowmark`.
+- Python build (library / newest patch): `uvx --from flowmark==0.7.2 flowmark`.
 
 <!-- END FLOWMARK INTEGRATION -->

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ Run `flowmark --help`, `flowmark --docs`, or `flowmark --skill` for more.
 Hand your agent this one instruction:
 
 > Set up Flowmark to keep this project’s Markdown auto-formatted.
-> Run `uvx --from flowmark==0.7.1 flowmark --skill` for details.
+> Run `uvx --from flowmark==0.7.2 flowmark --skill` for details.
 
-Or run `uvx --from flowmark==0.7.1 flowmark --install-skill` to manually install the
+Or run `uvx --from flowmark==0.7.2 flowmark --install-skill` to manually install the
 skill into `.agents/`, `.claude/`, and `AGENTS.md` (see
 [How to Install the Skill](#how-to-install-the-skill)).
 
@@ -551,7 +551,7 @@ A single command everyone (and CI) runs.
 Makefile target:
 
 ```makefile
-FLOWMARK := uvx --from flowmark==0.7.1 flowmark
+FLOWMARK := uvx --from flowmark==0.7.2 flowmark
 
 format-docs:
 	$(FLOWMARK) --auto .
@@ -562,7 +562,7 @@ Or as an npm script in `package.json`:
 ```json
 {
   "scripts": {
-    "format:docs": "uvx --from flowmark==0.7.1 flowmark --auto ."
+    "format:docs": "uvx --from flowmark==0.7.2 flowmark --auto ."
   }
 }
 ```
@@ -576,7 +576,7 @@ pre-commit:
   commands:
     flowmark:
       glob: "*.{md,mdc,markdown}"
-      run: uvx --from flowmark==0.7.1 flowmark --auto {staged_files}
+      run: uvx --from flowmark==0.7.2 flowmark --auto {staged_files}
       stage_fixed: true
 ```
 
@@ -586,7 +586,7 @@ directly from your `.pre-commit-config.yaml` without writing a `local` hook:
 ```yaml
 repos:
   - repo: https://github.com/jlevy/flowmark
-    rev: v0.7.1
+    rev: v0.7.2
     hooks:
       - id: flowmark          # auto-format Markdown in place
       # - id: flowmark-check  # or: check only, fail if files would change (for CI)
@@ -609,7 +609,7 @@ change, without writing.
 Pair it with `--auto` so CI validates the same formatting the auto-fix path applies:
 
 ```yaml
-- run: uvx --from flowmark==0.7.1 flowmark --auto --check .
+- run: uvx --from flowmark==0.7.2 flowmark --auto --check .
 ```
 
 ### 5. Exclude generated and vendored Markdown

--- a/skills/flowmark/SKILL.md
+++ b/skills/flowmark/SKILL.md
@@ -34,7 +34,7 @@ If `flowmark` is not on `PATH`, run it with a version-pinned runner (never `@lat
 # Recommended: fast native Rust port
 uvx --from flowmark-rs==0.3.0 flowmark --auto FILE
 # Python reference (library API or newest patch releases)
-uvx --from flowmark==0.7.1 flowmark --auto FILE
+uvx --from flowmark==0.7.2 flowmark --auto FILE
 ```
 
 ## When to Use It

--- a/src/flowmark/skill.py
+++ b/src/flowmark/skill.py
@@ -69,7 +69,7 @@ _RS_VERSION_PLACEHOLDER = "__FLOWMARK_RS_VERSION__"  # sibling Rust port (flowma
 # version (see docs/publishing.md release checklist) and re-run `make format`.
 # Rust port: this becomes flowmark-rs's own release version — see the porting
 # contract above.
-DISCOVERY_VERSION = "0.7.1"
+DISCOVERY_VERSION = "0.7.2"
 
 # Recommended pin for the fast Rust port (github.com/jlevy/flowmark-rs) — the default the
 # skill suggests. flowmark and flowmark-rs are SEPARATE PyPI packages with independent


### PR DESCRIPTION
## Summary

Final PR before tagging **v0.7.2**. Bumps `DISCOVERY_VERSION` from `0.7.1` to `0.7.2` (the single source of truth for the `uvx --from flowmark==<X.Y.Z>` bootstrap pin) and propagates it to every shipped artifact via `make format`. The independent `flowmark-rs` pin stays at `0.3.0`.

After this merges, `v0.7.2` will be released by publishing a GitHub Release on `main`.

## Changes

- `src/flowmark/skill.py`: `DISCOVERY_VERSION = "0.7.2"`.
- Regenerated runner-pin examples in `README.md`, the discovery copy `skills/flowmark/SKILL.md`, and the dogfooded skill surfaces (`.agents/`, `.claude/`, `AGENTS.md` block).

## Test Plan

- [x] `make check-release-pin VERSION=0.7.2` → `Release pin OK: all shipped artifacts pin flowmark==0.7.2`.
- [x] `make lint` → clean; `make test` → 133 passed.
- [x] `flowmark-rs==0.3.0` pin unchanged (independent source of truth); `flowmark==0.7.2` updated everywhere.
- [x] Skill-artifact drift guards pass (discovery copy matches generator, flowmark-stable, no `@latest`).

https://claude.ai/code/session_01KC2RdyGySfZcvQZxjcwQhY

---
_Generated by [Claude Code](https://claude.ai/code/session_01KC2RdyGySfZcvQZxjcwQhY)_