### PR TITLE
feat: consolidate Flowmark skill guidance

### DIFF
--- a/.agents/skills/flowmark/SKILL.md
+++ b/.agents/skills/flowmark/SKILL.md
@@ -40,8 +40,10 @@ uvx --from flowmark==0.7.2 flowmark --auto FILE
 
 ## Adopt Flowmark in a Repository
 
-For a repository-wide migration, Makefile wiring, `.flowmarkignore`, commit hooks, CI
-policy, and disabling Prettier or other competing Markdown formatters, read
+If this skill came from `flowmark --skill`, run the same runner with `--install-skill`
+from the project root to materialize the complete bundle.
+Then, for a repository-wide migration, Makefile wiring, `.flowmarkignore`, commit hooks,
+CI policy, and disabling Prettier or other competing Markdown formatters, read
 [project-setup.md](references/project-setup.md) in full before editing.
 
 ## Full Documentation

--- a/.agents/skills/flowmark/SKILL.md
+++ b/.agents/skills/flowmark/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: flowmark
-description: Fast, consistent Markdown auto-formatter for typographic cleanup (smart quotes, ellipses), normalized formatting, and optional clean line wrapping for small, readable git diffs. Use when creating, editing, or normalizing Markdown (.md) files, cleaning up LLM-generated Markdown, or when the user mentions flowmark or formatting Markdown.
+description: Fast, consistent Markdown auto-formatter for typographic cleanup, normalization, and clean semantic line breaks. Use when creating, editing, or cleaning Markdown; formatting LLM-generated docs; adopting Flowmark in a repository; adding Markdown format scripts or commit hooks; or replacing Prettier or another Markdown formatter.
 allowed-tools: Bash(flowmark:*), Bash(uvx:*), Read, Write
 ---
-<!-- DO NOT EDIT: `flowmark --install-skill` (format=f02 surface=skill-md) -->
+<!-- DO NOT EDIT: `flowmark --install-skill` (format=f03 surface=skill-md) -->
 
 # Flowmark - Markdown Auto-Formatter
 
@@ -12,7 +12,7 @@ Run it on Markdown you generate or edit so committed diffs stay small and readab
 It is conservative and safe to run on every file: it never modifies code blocks or
 inline code.
 
-## Default Usage
+## Format Markdown
 
 Format in place with all auto-formatting (typography, cleanups, semantic line breaks):
 
@@ -23,26 +23,26 @@ flowmark --auto .      # whole tree (respects .gitignore and .flowmarkignore)
 
 Omit `--auto` to preview to stdout; pipe stdin with `-` (e.g. `cat FILE | flowmark -`).
 
-Flowmark ships as two packages with identical formatting and the same `flowmark`
-command: the fast native Rust port [`flowmark-rs`](https://github.com/jlevy/flowmark-rs)
-(recommended) and the Python reference [`flowmark`](https://github.com/jlevy/flowmark).
-Prefer flowmark-rs; reach for the Python build only when you need its library API or the
-very latest patch release not yet ported to Rust.
-If `flowmark` is not on `PATH`, run it with a version-pinned runner (never `@latest`):
+Use `flowmark` when it is already on `PATH`. Otherwise use the fast
+[Rust port](https://github.com/jlevy/flowmark-rs) with a version-pinned `uvx` runner
+(never `@latest`):
 
 ```bash
-# Recommended: fast native Rust port
-uvx --from flowmark-rs==0.3.0 flowmark --auto FILE
-# Python reference (library API or newest patch releases)
+uvx --from flowmark-rs==0.3.1 flowmark --auto FILE
+```
+
+The [Python reference](https://github.com/jlevy/flowmark) remains available when its
+library API or a newer unported patch is required:
+
+```bash
 uvx --from flowmark==0.7.2 flowmark --auto FILE
 ```
 
-## When to Use It
+## Adopt Flowmark in a Repository
 
-- Auto-format Markdown you create or edit, before committing.
-- Normalize and clean up LLM-generated Markdown.
-- Typographic cleanup (smart quotes, ellipses) and consistent formatting.
-- Optional semantic (sentence-based) line breaks for cleaner git diffs (`--semantic`).
+For a repository-wide migration, Makefile wiring, `.flowmarkignore`, commit hooks, CI
+policy, and disabling Prettier or other competing Markdown formatters, read
+[project-setup.md](references/project-setup.md) in full before editing.
 
 ## Full Documentation
 
@@ -52,9 +52,8 @@ Use the CLI rather than reproducing details here:
 - `flowmark --help` — every flag: `--semantic`, `--smartquotes`, `--ellipses`,
   `--width`, `--check`, list spacing, and file discovery
   (`--extend-include`/`--extend-exclude`).
-- `flowmark --docs` — the full guide: editor on-save setup (VS Code/Cursor), project
-  wiring (pre-commit/CI, `.flowmarkignore`), config files, the Python library API, and
-  installing this skill for other agents (`flowmark --install-skill`).
+- `flowmark --docs` — the full guide: configuration, file discovery, editor setup, the
+  Python library API, and installing this skill (`flowmark --install-skill`).
 
 <!-- This document follows common-doc-guidelines.md.
 See github.com/jlevy/practical-prose and review guidelines before editing.

--- a/.agents/skills/flowmark/references/project-setup.md
+++ b/.agents/skills/flowmark/references/project-setup.md
@@ -62,7 +62,7 @@ Lefthook can format and stage Markdown without turning style into a separate fai
 pre-commit:
   commands:
     flowmark:
-      glob: "*.md"
+      glob: "*.{md,mdc,markdown}"
       run: uvx --from flowmark-rs==0.3.1 flowmark --auto --force-exclude {staged_files}
       stage_fixed: true
 ```
@@ -81,12 +81,13 @@ repos:
         name: flowmark
         entry: uvx --from flowmark-rs==0.3.1 flowmark --auto --force-exclude
         language: system
-        types: [markdown]
+        files: '\.(md|mdc|markdown)$'
 ```
 
-The `pre-commit` framework stops the first commit after modifying files; stage the fixes
-and retry. Use Lefthook with `stage_fixed: true` when transparent auto-staging is
-preferred.
+Keep both hook selectors aligned with any Markdown extensions the repository discovers
+through `--extend-include`. The `pre-commit` framework stops the first commit after
+modifying files; stage the fixes and retry.
+Use Lefthook with `stage_fixed: true` when transparent auto-staging is preferred.
 
 ## Disable Competing Markdown Formatters
 

--- a/.agents/skills/flowmark/references/project-setup.md
+++ b/.agents/skills/flowmark/references/project-setup.md
@@ -1,0 +1,110 @@
+<!-- DO NOT EDIT: `flowmark --install-skill` (format=f03 surface=skill-reference) -->
+
+# Project Setup and Migration
+
+Use this workflow when adopting Flowmark across a repository.
+Keep one `flowmark` skill; project setup is a use case of that skill, not a separate
+skill.
+
+## Migration Checklist
+
+1. Find the Markdown sources and identify generated, vendored, fixture, and golden files
+   that must retain byte-exact content.
+2. Add those paths to `.flowmarkignore`.
+3. Make Flowmark the only formatter that owns Markdown.
+   Disable Markdown in Prettier, Biome, dprint, editor format-on-save settings, and
+   existing Markdown hooks.
+4. Add one pinned project command and run it once over the repository.
+   Review and commit the baseline reformat separately from content changes.
+5. Add an auto-fixing commit hook.
+   Prefer a hook that stages its fixes so formatting does not become a manual gate.
+6. Do not fail the main build only for ordinary Markdown formatting drift.
+   Keep formatting local and automatic; reserve CI drift checks for generated or
+   contractually byte-exact documentation.
+
+## Pinned Project Command
+
+Prefer the Rust port through `uvx`:
+
+```makefile
+FLOWMARK := uvx --from flowmark-rs==0.3.1 flowmark
+
+.PHONY: format-docs
+format-docs:
+	$(FLOWMARK) --auto .
+```
+
+Passing `.` lets Flowmark discover files once and honor `.gitignore` and
+`.flowmarkignore` from the repository root.
+Avoid shell `find` pipelines or per-directory invocations unless the repository requires
+them.
+
+Start `.flowmarkignore` with content Flowmark must not rewrite:
+
+```gitignore
+# Generated or vendored Markdown
+docs/api/_generated/
+third_party/
+
+# Byte-exact fixtures and golden files
+tests/fixtures/
+tests/golden/
+```
+
+When documentation is generated, format canonical sources first, then regenerate their
+mirrors. Exclude generated mirrors from Flowmark so there is one source of truth.
+
+## Auto-Fix on Commit
+
+Lefthook can format and stage Markdown without turning style into a separate failure:
+
+```yaml
+pre-commit:
+  commands:
+    flowmark:
+      glob: "*.md"
+      run: uvx --from flowmark-rs==0.3.1 flowmark --auto --force-exclude {staged_files}
+      stage_fixed: true
+```
+
+`--force-exclude` applies `.flowmarkignore` even though the hook passes explicit file
+paths. If generated docs must be refreshed after formatting, call one repository script
+or Make target that performs both operations in the required order.
+
+For the `pre-commit` framework, use a local system hook with the same pinned command:
+
+```yaml
+repos:
+  - repo: local
+    hooks:
+      - id: flowmark
+        name: flowmark
+        entry: uvx --from flowmark-rs==0.3.1 flowmark --auto --force-exclude
+        language: system
+        types: [markdown]
+```
+
+The `pre-commit` framework stops the first commit after modifying files; stage the fixes
+and retry. Use Lefthook with `stage_fixed: true` when transparent auto-staging is
+preferred.
+
+## Disable Competing Markdown Formatters
+
+For Prettier, exclude Markdown in `.prettierignore`:
+
+```gitignore
+*.md
+```
+
+Also remove Markdown-specific Prettier hooks and editor defaults.
+If Flowmark owns MDX or another extension via `--extend-include`, exclude that extension
+from Prettier too.
+
+Apply the same ownership rule to other tools: keep them for code and data formats, but
+remove Markdown from their include globs and format-on-save configuration.
+Do not run two Markdown formatters sequentially; they can churn each other’s output and
+make hooks or CI nondeterministic.
+
+<!-- This document follows common-doc-guidelines.md.
+See github.com/jlevy/practical-prose and review guidelines before editing.
+-->

--- a/.claude/skills/flowmark/SKILL.md
+++ b/.claude/skills/flowmark/SKILL.md
@@ -40,8 +40,10 @@ uvx --from flowmark==0.7.2 flowmark --auto FILE
 
 ## Adopt Flowmark in a Repository
 
-For a repository-wide migration, Makefile wiring, `.flowmarkignore`, commit hooks, CI
-policy, and disabling Prettier or other competing Markdown formatters, read
+If this skill came from `flowmark --skill`, run the same runner with `--install-skill`
+from the project root to materialize the complete bundle.
+Then, for a repository-wide migration, Makefile wiring, `.flowmarkignore`, commit hooks,
+CI policy, and disabling Prettier or other competing Markdown formatters, read
 [project-setup.md](references/project-setup.md) in full before editing.
 
 ## Full Documentation

--- a/.claude/skills/flowmark/SKILL.md
+++ b/.claude/skills/flowmark/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: flowmark
-description: Fast, consistent Markdown auto-formatter for typographic cleanup (smart quotes, ellipses), normalized formatting, and optional clean line wrapping for small, readable git diffs. Use when creating, editing, or normalizing Markdown (.md) files, cleaning up LLM-generated Markdown, or when the user mentions flowmark or formatting Markdown.
+description: Fast, consistent Markdown auto-formatter for typographic cleanup, normalization, and clean semantic line breaks. Use when creating, editing, or cleaning Markdown; formatting LLM-generated docs; adopting Flowmark in a repository; adding Markdown format scripts or commit hooks; or replacing Prettier or another Markdown formatter.
 allowed-tools: Bash(flowmark:*), Bash(uvx:*), Read, Write
 ---
-<!-- DO NOT EDIT: `flowmark --install-skill` (format=f02 surface=skill-md) -->
+<!-- DO NOT EDIT: `flowmark --install-skill` (format=f03 surface=skill-md) -->
 
 # Flowmark - Markdown Auto-Formatter
 
@@ -12,7 +12,7 @@ Run it on Markdown you generate or edit so committed diffs stay small and readab
 It is conservative and safe to run on every file: it never modifies code blocks or
 inline code.
 
-## Default Usage
+## Format Markdown
 
 Format in place with all auto-formatting (typography, cleanups, semantic line breaks):
 
@@ -23,26 +23,26 @@ flowmark --auto .      # whole tree (respects .gitignore and .flowmarkignore)
 
 Omit `--auto` to preview to stdout; pipe stdin with `-` (e.g. `cat FILE | flowmark -`).
 
-Flowmark ships as two packages with identical formatting and the same `flowmark`
-command: the fast native Rust port [`flowmark-rs`](https://github.com/jlevy/flowmark-rs)
-(recommended) and the Python reference [`flowmark`](https://github.com/jlevy/flowmark).
-Prefer flowmark-rs; reach for the Python build only when you need its library API or the
-very latest patch release not yet ported to Rust.
-If `flowmark` is not on `PATH`, run it with a version-pinned runner (never `@latest`):
+Use `flowmark` when it is already on `PATH`. Otherwise use the fast
+[Rust port](https://github.com/jlevy/flowmark-rs) with a version-pinned `uvx` runner
+(never `@latest`):
 
 ```bash
-# Recommended: fast native Rust port
-uvx --from flowmark-rs==0.3.0 flowmark --auto FILE
-# Python reference (library API or newest patch releases)
+uvx --from flowmark-rs==0.3.1 flowmark --auto FILE
+```
+
+The [Python reference](https://github.com/jlevy/flowmark) remains available when its
+library API or a newer unported patch is required:
+
+```bash
 uvx --from flowmark==0.7.2 flowmark --auto FILE
 ```
 
-## When to Use It
+## Adopt Flowmark in a Repository
 
-- Auto-format Markdown you create or edit, before committing.
-- Normalize and clean up LLM-generated Markdown.
-- Typographic cleanup (smart quotes, ellipses) and consistent formatting.
-- Optional semantic (sentence-based) line breaks for cleaner git diffs (`--semantic`).
+For a repository-wide migration, Makefile wiring, `.flowmarkignore`, commit hooks, CI
+policy, and disabling Prettier or other competing Markdown formatters, read
+[project-setup.md](references/project-setup.md) in full before editing.
 
 ## Full Documentation
 
@@ -52,9 +52,8 @@ Use the CLI rather than reproducing details here:
 - `flowmark --help` — every flag: `--semantic`, `--smartquotes`, `--ellipses`,
   `--width`, `--check`, list spacing, and file discovery
   (`--extend-include`/`--extend-exclude`).
-- `flowmark --docs` — the full guide: editor on-save setup (VS Code/Cursor), project
-  wiring (pre-commit/CI, `.flowmarkignore`), config files, the Python library API, and
-  installing this skill for other agents (`flowmark --install-skill`).
+- `flowmark --docs` — the full guide: configuration, file discovery, editor setup, the
+  Python library API, and installing this skill (`flowmark --install-skill`).
 
 <!-- This document follows common-doc-guidelines.md.
 See github.com/jlevy/practical-prose and review guidelines before editing.

--- a/.claude/skills/flowmark/references/project-setup.md
+++ b/.claude/skills/flowmark/references/project-setup.md
@@ -62,7 +62,7 @@ Lefthook can format and stage Markdown without turning style into a separate fai
 pre-commit:
   commands:
     flowmark:
-      glob: "*.md"
+      glob: "*.{md,mdc,markdown}"
       run: uvx --from flowmark-rs==0.3.1 flowmark --auto --force-exclude {staged_files}
       stage_fixed: true
 ```
@@ -81,12 +81,13 @@ repos:
         name: flowmark
         entry: uvx --from flowmark-rs==0.3.1 flowmark --auto --force-exclude
         language: system
-        types: [markdown]
+        files: '\.(md|mdc|markdown)$'
 ```
 
-The `pre-commit` framework stops the first commit after modifying files; stage the fixes
-and retry. Use Lefthook with `stage_fixed: true` when transparent auto-staging is
-preferred.
+Keep both hook selectors aligned with any Markdown extensions the repository discovers
+through `--extend-include`. The `pre-commit` framework stops the first commit after
+modifying files; stage the fixes and retry.
+Use Lefthook with `stage_fixed: true` when transparent auto-staging is preferred.
 
 ## Disable Competing Markdown Formatters
 

--- a/.claude/skills/flowmark/references/project-setup.md
+++ b/.claude/skills/flowmark/references/project-setup.md
@@ -1,0 +1,110 @@
+<!-- DO NOT EDIT: `flowmark --install-skill` (format=f03 surface=skill-reference) -->
+
+# Project Setup and Migration
+
+Use this workflow when adopting Flowmark across a repository.
+Keep one `flowmark` skill; project setup is a use case of that skill, not a separate
+skill.
+
+## Migration Checklist
+
+1. Find the Markdown sources and identify generated, vendored, fixture, and golden files
+   that must retain byte-exact content.
+2. Add those paths to `.flowmarkignore`.
+3. Make Flowmark the only formatter that owns Markdown.
+   Disable Markdown in Prettier, Biome, dprint, editor format-on-save settings, and
+   existing Markdown hooks.
+4. Add one pinned project command and run it once over the repository.
+   Review and commit the baseline reformat separately from content changes.
+5. Add an auto-fixing commit hook.
+   Prefer a hook that stages its fixes so formatting does not become a manual gate.
+6. Do not fail the main build only for ordinary Markdown formatting drift.
+   Keep formatting local and automatic; reserve CI drift checks for generated or
+   contractually byte-exact documentation.
+
+## Pinned Project Command
+
+Prefer the Rust port through `uvx`:
+
+```makefile
+FLOWMARK := uvx --from flowmark-rs==0.3.1 flowmark
+
+.PHONY: format-docs
+format-docs:
+	$(FLOWMARK) --auto .
+```
+
+Passing `.` lets Flowmark discover files once and honor `.gitignore` and
+`.flowmarkignore` from the repository root.
+Avoid shell `find` pipelines or per-directory invocations unless the repository requires
+them.
+
+Start `.flowmarkignore` with content Flowmark must not rewrite:
+
+```gitignore
+# Generated or vendored Markdown
+docs/api/_generated/
+third_party/
+
+# Byte-exact fixtures and golden files
+tests/fixtures/
+tests/golden/
+```
+
+When documentation is generated, format canonical sources first, then regenerate their
+mirrors. Exclude generated mirrors from Flowmark so there is one source of truth.
+
+## Auto-Fix on Commit
+
+Lefthook can format and stage Markdown without turning style into a separate failure:
+
+```yaml
+pre-commit:
+  commands:
+    flowmark:
+      glob: "*.md"
+      run: uvx --from flowmark-rs==0.3.1 flowmark --auto --force-exclude {staged_files}
+      stage_fixed: true
+```
+
+`--force-exclude` applies `.flowmarkignore` even though the hook passes explicit file
+paths. If generated docs must be refreshed after formatting, call one repository script
+or Make target that performs both operations in the required order.
+
+For the `pre-commit` framework, use a local system hook with the same pinned command:
+
+```yaml
+repos:
+  - repo: local
+    hooks:
+      - id: flowmark
+        name: flowmark
+        entry: uvx --from flowmark-rs==0.3.1 flowmark --auto --force-exclude
+        language: system
+        types: [markdown]
+```
+
+The `pre-commit` framework stops the first commit after modifying files; stage the fixes
+and retry. Use Lefthook with `stage_fixed: true` when transparent auto-staging is
+preferred.
+
+## Disable Competing Markdown Formatters
+
+For Prettier, exclude Markdown in `.prettierignore`:
+
+```gitignore
+*.md
+```
+
+Also remove Markdown-specific Prettier hooks and editor defaults.
+If Flowmark owns MDX or another extension via `--extend-include`, exclude that extension
+from Prettier too.
+
+Apply the same ownership rule to other tools: keep them for code and data formats, but
+remove Markdown from their include globs and format-on-save configuration.
+Do not run two Markdown formatters sequentially; they can churn each other’s output and
+make hooks or CI nondeterministic.
+
+<!-- This document follows common-doc-guidelines.md.
+See github.com/jlevy/practical-prose and review guidelines before editing.
+-->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
         run: npx tryscript@0.1.7 run tests/tryscript/*.tryscript.md
 
       - name: Validate published skill frontmatter
-        # Runs `npx skills-ref validate skills/flowmark` to catch a malformed
+        # Runs a pinned `skills-ref validate skills/flowmark` to catch a malformed
         # `name`/`description`/`allowed-tools` on the public discovery copy before
-        # `npx skills add jlevy/flowmark` users hit it.
+        # `npx skills add jlevy/flowmark@flowmark` users hit it.
         run: make validate-skill

--- a/.tbd/config.yml
+++ b/.tbd/config.yml
@@ -1,5 +1,9 @@
-tbd_format: f04
+tbd_format: f06
 tbd_version: 0.1.12
+# tbd_upgrades: tbd versions that have run `tbd setup` in this repo (oldest first);
+# tbd_version above is the most recent. Informational; updated automatically by setup.
+tbd_upgrades:
+  - version: 0.1.12
 display:
   id_prefix: fm
 sync:
@@ -10,27 +14,25 @@ settings:
   auto_sync: false
   doc_auto_sync_hours: 24
   use_gh_cli: true
-# Documentation cache configuration.
-# files: Maps destination paths (relative to .tbd/docs/) to source locations.
-#   Sources can be:
-#   - internal: prefix for bundled docs (e.g., "internal:shortcuts/standard/code-review-and-commit.md")
-#   - Full URL for external docs (e.g., "https://raw.githubusercontent.com/org/repo/main/file.md")
-# lookup_path: Search paths for doc lookup (like shell $PATH). Earlier paths take precedence.
-#
-# To sync docs: tbd sync --docs
-# To check status: tbd sync --status
-#
-# Auto-sync: Docs are automatically synced when stale (default: every 24 hours).
-# Configure with settings.doc_auto_sync_hours (0 = disabled).
+# Documentation cache: the docs tbd serves (guidelines, shortcuts, templates), synced
+# into the gitignored .tbd/docs/ cache. Managed with `tbd docs` (run `tbd docs --help`).
+# files: destination path (under .tbd/docs/) -> source docref. Common source forms:
+#   - internal:<path>                          bundled with tbd (e.g. internal:guidelines/typescript-rules.md)
+#   - github:owner/repo@ref//path/to/file.md   a file in a git repo (gitlab: too; @ref optional)
+#   - https://host/path/file.md                a plain URL, kept verbatim
+#   Full docref grammar: `tbd docs show docref-format`.
+# lookup_path: doc lookup search order, like shell $PATH (earlier paths win).
+# Refresh the cache with `tbd docs sync`; it also auto-syncs when stale
+# (settings.doc_auto_sync_hours, default 24; 0 disables).
 docs_cache:
-  lookup_path:
-    - .tbd/docs/shortcuts/system
-    - .tbd/docs/shortcuts/standard
   files:
+    references/tbd-docs.md: internal:tbd-docs.md
+    references/tbd-design.md: internal:tbd-design.md
     shortcuts/system/shortcut-explanation.md: internal:shortcuts/system/shortcut-explanation.md
     shortcuts/system/skill-baseline.md: internal:shortcuts/system/skill-baseline.md
     shortcuts/system/skill-brief.md: internal:shortcuts/system/skill-brief.md
     shortcuts/system/skill-minimal.md: internal:shortcuts/system/skill-minimal.md
+    shortcuts/standard/address-pr-review.md: internal:shortcuts/standard/address-pr-review.md
     shortcuts/standard/agent-handoff.md: internal:shortcuts/standard/agent-handoff.md
     shortcuts/standard/checkout-third-party-repo.md: internal:shortcuts/standard/checkout-third-party-repo.md
     shortcuts/standard/code-cleanup-all.md: internal:shortcuts/standard/code-cleanup-all.md
@@ -50,6 +52,7 @@ docs_cache:
     shortcuts/standard/new-shortcut.md: internal:shortcuts/standard/new-shortcut.md
     shortcuts/standard/new-validation-plan.md: internal:shortcuts/standard/new-validation-plan.md
     shortcuts/standard/plan-implementation-with-beads.md: internal:shortcuts/standard/plan-implementation-with-beads.md
+    shortcuts/standard/pr-review-workflows.md: internal:shortcuts/standard/pr-review-workflows.md
     shortcuts/standard/precommit-process.md: internal:shortcuts/standard/precommit-process.md
     shortcuts/standard/review-code-python.md: internal:shortcuts/standard/review-code-python.md
     shortcuts/standard/review-code-typescript.md: internal:shortcuts/standard/review-code-typescript.md
@@ -58,6 +61,7 @@ docs_cache:
     shortcuts/standard/revise-all-architecture-docs.md: internal:shortcuts/standard/revise-all-architecture-docs.md
     shortcuts/standard/revise-architecture-doc.md: internal:shortcuts/standard/revise-architecture-doc.md
     shortcuts/standard/setup-github-cli.md: internal:shortcuts/standard/setup-github-cli.md
+    shortcuts/standard/suggest-upstream-improvements.md: internal:shortcuts/standard/suggest-upstream-improvements.md
     shortcuts/standard/sync-failure-recovery.md: internal:shortcuts/standard/sync-failure-recovery.md
     shortcuts/standard/update-specs-status.md: internal:shortcuts/standard/update-specs-status.md
     shortcuts/standard/welcome-user.md: internal:shortcuts/standard/welcome-user.md
@@ -72,7 +76,7 @@ docs_cache:
     guidelines/error-handling-rules.md: internal:guidelines/error-handling-rules.md
     guidelines/general-coding-rules.md: internal:guidelines/general-coding-rules.md
     guidelines/general-comment-rules.md: internal:guidelines/general-comment-rules.md
-    guidelines/general-eng-assistant-rules.md: internal:guidelines/general-eng-assistant-rules.md
+    guidelines/general-eng-agent-principles.md: internal:guidelines/general-eng-agent-principles.md
     guidelines/general-tdd-guidelines.md: internal:guidelines/general-tdd-guidelines.md
     guidelines/general-testing-rules.md: internal:guidelines/general-testing-rules.md
     guidelines/golden-testing-guidelines.md: internal:guidelines/golden-testing-guidelines.md
@@ -92,3 +96,8 @@ docs_cache:
     templates/plan-spec.md: internal:templates/plan-spec.md
     templates/qa-playbook.md: internal:templates/qa-playbook.md
     templates/research-brief.md: internal:templates/research-brief.md
+    references/docmap-format.md: internal:references/docmap-format.md
+    references/docref-format.md: internal:references/docref-format.md
+  lookup_path:
+    - .tbd/docs/shortcuts/system
+    - .tbd/docs/shortcuts/standard

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ actions rather than telling them to run commands.
 
 <!-- END TBD INTEGRATION -->
 
-<!-- BEGIN FLOWMARK INTEGRATION format=f02 surface=agents-md -->
+<!-- BEGIN FLOWMARK INTEGRATION format=f03 surface=agents-md -->
 ## flowmark
 
 Auto-format Markdown with `flowmark` for clean, semantic git diffs.
@@ -32,7 +32,7 @@ Auto-format Markdown with `flowmark` for clean, semantic git diffs.
 - Run `flowmark --auto <files>` on Markdown you create or edit.
 - Run `flowmark --docs` for full usage and `flowmark --skill` for the skill.
 - If `flowmark` is not on `PATH`, use a pinned `uvx` runner (never `@latest`).
-- Fast Rust port (recommended): `uvx --from flowmark-rs==0.3.0 flowmark`.
+- Fast Rust port (recommended): `uvx --from flowmark-rs==0.3.1 flowmark`.
 - Python build (library / newest patch): `uvx --from flowmark==0.7.2 flowmark`.
 
 <!-- END FLOWMARK INTEGRATION -->

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ format-docs:
 
 # Regenerate checked-in generated docs from their sources:
 #   README.md            <- docs/shared + docs/templates (generate-python-readme.py)
-#   skills/flowmark/SKILL.md (published discovery copy) <- generate-skill-discovery.py
+#   skills/flowmark/ (published skill bundle) <- generate-skill-discovery.py
 #   .agents/.claude/AGENTS.md skill surfaces <- `flowmark --install-skill` (dogfood)
 # The skill drift test (tests/test_skill_artifacts.py) fails if any pin is stale.
 generate: generate-readme generate-skill generate-skill-install
@@ -43,7 +43,7 @@ generate-skill-install:
 
 # Validate the published skill against the Agent Skills spec (needs network/npx).
 validate-skill:
-	npx skills-ref validate skills/flowmark
+	npx --yes skills-ref@0.1.5 validate skills/flowmark
 
 # Verify the skill's uvx bootstrap pin is consistent across all shipped artifacts.
 # Pass VERSION=X.Y.Z to also assert it matches the release being cut; with no VERSION

--- a/README.md
+++ b/README.md
@@ -557,11 +557,15 @@ own.
 
 ### How to Install the Skill
 
+The main [Flowmark repository](https://github.com/jlevy/flowmark) owns the public skill
+bundle and its documentation.
+The Rust repository supplies the recommended fast implementation, not a second skill
+distribution.
+
 There are three install paths, ordered by what most users want first:
 
-**1. Cross-agent package manager (no flowmark prerequisite).** If you just want the
-skill on disk for any supported agent and don’t already have flowmark, use the
-`skills.sh` installer.
+**1. Install from the main Flowmark repository (recommended).** If you just want the
+skill on disk for any supported agent, use the `skills.sh` installer.
 It copies the published discovery copy into `.agents/skills/` and symlinks it into each
 agent’s native location (Claude Code, Codex, Cursor, Copilot, Gemini, …). The discovery
 copy bootstraps its own pinned `uvx` invocation, so no prior flowmark install is
@@ -571,8 +575,9 @@ required:
 npx skills add jlevy/flowmark@flowmark
 ```
 
-**2. Direct install via the flowmark CLI (recommended once you have flowmark).** Run
-from the repo root.
+**2. Direct install via either flowmark CLI.** Run from the repo root.
+The Python and Rust CLIs install the same skill bundle; this path is useful when either
+implementation is already available.
 By default this writes all three project-local surfaces: the portable
 `.agents/skills/flowmark/` (read by Codex, Gemini CLI, pi, and others), the
 `.claude/skills/flowmark/` mirror (Claude Code reads only that path), and a compact

--- a/README.md
+++ b/README.md
@@ -39,19 +39,17 @@ Both Python and Rust versions are best installed with
 No install needed for one-off usage:
 
 ```shell
-uvx flowmark-rs --help                  # For native-binary Rust
-uvx flowmark-rs --auto somefile.md
-uvx flowmark --help                     # For Python
-uvx flowmark --auto somefile.md
+uvx --from flowmark-rs==0.3.1 flowmark --help
+uvx --from flowmark-rs==0.3.1 flowmark --auto somefile.md
+uvx --from flowmark==0.7.2 flowmark --help  # Python reference
 ```
 
 ### Install as a Global CLI
 
 ```shell
-uv tool install --upgrade flowmark-rs   # For native-binary Rust
-uv tool install --upgrade flowmark      # For Python
-flowmark --auto somefile.md             # One file
-flowmark --auto .                       # Whole tree (respects .gitignore / .flowmarkignore)
+uv tool install flowmark-rs==0.3.1  # Native Rust CLI
+flowmark --auto somefile.md                         # One file
+flowmark --auto .                                   # Whole tree
 ```
 
 Run `flowmark --help`, `flowmark --docs`, or `flowmark --skill` for more.
@@ -61,10 +59,11 @@ Run `flowmark --help`, `flowmark --docs`, or `flowmark --skill` for more.
 Hand your agent this one instruction:
 
 > Set up Flowmark to keep this project’s Markdown auto-formatted.
-> Run `uvx --from flowmark==0.7.2 flowmark --skill` for details.
+> Install the Flowmark skill with `npx skills add jlevy/flowmark@flowmark` and follow
+> it.
 
-Or run `uvx --from flowmark==0.7.2 flowmark --install-skill` to manually install the
-skill into `.agents/`, `.claude/`, and `AGENTS.md` (see
+Or run `uvx --from flowmark-rs==0.3.1 flowmark --install-skill` to install the skill
+into `.agents/`, `.claude/`, and `AGENTS.md` directly (see
 [How to Install the Skill](#how-to-install-the-skill)).
 
 For consistency across users and supply chain security, it’s recommended to pin the
@@ -527,104 +526,20 @@ For batch formatting an entire project, use `flowmark --auto .` from the termina
 
 ## Recommended Project Setup
 
-To keep a repo’s Markdown consistently formatted across contributors and CI, **pin a
-flowmark version** and wire it into your existing build/hook plumbing.
-The same pattern works whether you reach for the Python build or the Rust port.
+Use one pinned Rust command everywhere:
 
-### 1. Pick a pinned invocation
-
-Avoid unpinned `flowmark@latest`: different contributors then silently run different
-versions and produce noisy diffs.
-
-- **Rust port (fastest)**: install the
-  [`flowmark-rs`](https://github.com/jlevy/flowmark-rs) binary at a specific release.
-  Identical formatting to the Python version; great when speed matters in hooks/CI.
-- **Python via `uvx` (zero-install)**: invoke as
-  `uvx --from flowmark==<X.Y.Z> flowmark --auto`. First call caches the wheel;
-  subsequent calls are fast.
-- **Python tool install**: `uv tool install flowmark==<X.Y.Z>` (or
-  `pip install flowmark==<X.Y.Z>` in a venv) puts `flowmark` on `PATH`.
-
-### 2. Add one project entry point
-
-A single command everyone (and CI) runs.
-Makefile target:
-
-```makefile
-FLOWMARK := uvx --from flowmark==0.7.2 flowmark
-
-format-docs:
-	$(FLOWMARK) --auto .
+```bash
+uvx --from flowmark-rs==0.3.1 flowmark --auto .
 ```
 
-Or as an npm script in `package.json`:
+Keep generated, vendored, and byte-exact Markdown in `.flowmarkignore`; disable Markdown
+in Prettier and other competing formatters; and run Flowmark as an auto-fixing commit
+hook. Ordinary Markdown style drift should not fail the main build when the commit hook
+can fix it locally.
 
-```json
-{
-  "scripts": {
-    "format:docs": "uvx --from flowmark==0.7.2 flowmark --auto ."
-  }
-}
-```
-
-### 3. Run on pre-commit
-
-[lefthook](https://lefthook.dev) example (`lefthook.yml`):
-
-```yaml
-pre-commit:
-  commands:
-    flowmark:
-      glob: "*.{md,mdc,markdown}"
-      run: uvx --from flowmark==0.7.2 flowmark --auto {staged_files}
-      stage_fixed: true
-```
-
-Flowmark also ships [pre-commit](https://pre-commit.com) hooks, so you can use it
-directly from your `.pre-commit-config.yaml` without writing a `local` hook:
-
-```yaml
-repos:
-  - repo: https://github.com/jlevy/flowmark
-    rev: v0.7.2
-    hooks:
-      - id: flowmark          # auto-format Markdown in place
-      # - id: flowmark-check  # or: check only, fail if files would change (for CI)
-```
-
-These run via the [pre-commit](https://pre-commit.com) framework (not GitHub-specific):
-install it once with `pre-commit install`, and it builds Flowmark in an isolated
-environment on first use — no global install or extra dependency needed.
-Both hooks pass `--force-exclude`, so your `.flowmarkignore` and other exclusions are
-respected on the staged files pre-commit hands them (the same approach `ruff-pre-commit`
-uses); the `flowmark-check` hook also mirrors `--auto` so it validates exactly what the
-auto-fix hook would write.
-
-A `husky` setup works the same way; the key is the pinned invocation.
-
-### 4. Add a CI check
-
-Use `--check` (or the `flowmark-check` pre-commit hook) to fail if anything would
-change, without writing.
-Pair it with `--auto` so CI validates the same formatting the auto-fix path applies:
-
-```yaml
-- run: uvx --from flowmark==0.7.2 flowmark --auto --check .
-```
-
-### 5. Exclude generated and vendored Markdown
-
-Add a `.flowmarkignore` (same syntax as `.gitignore`) so batch formatting only touches
-files you own:
-
-```
-docs/api/_generated/
-attic/
-third_party/
-```
-
-`flowmark --auto .` always respects `.flowmarkignore` and `.gitignore`. For editor-side
-on-save formatting, see [Use in VSCode/Cursor](#use-in-vscodecursor) above.
+For a migration checklist and copyable Makefile, Lefthook, `pre-commit`, and Prettier
+examples, see
+[Project Setup and Migration](skills/flowmark/references/project-setup.md).
 
 ## Agent Use (Claude Code and Other AI Coding Agents)
 
@@ -649,7 +564,7 @@ copy bootstraps its own pinned `uvx` invocation, so no prior flowmark install is
 required:
 
 ```bash
-npx skills add jlevy/flowmark
+npx skills add jlevy/flowmark@flowmark
 ```
 
 **2. Direct install via the flowmark CLI (recommended once you have flowmark).** Run
@@ -713,8 +628,7 @@ In ephemeral or cloud agent environments where nothing is installed, run it via 
 a newer release):
 
 ```bash
-uvx --from flowmark==<version> flowmark --auto README.md   # Python
-# or use the Rust binary (flowmark-rs) for maximum speed
+uvx --from flowmark-rs==0.3.1 flowmark --auto README.md
 ```
 
 ## How Does Flowmark Compare to Other Markdown Auto-Formatters?

--- a/README.md
+++ b/README.md
@@ -62,9 +62,13 @@ Hand your agent this one instruction:
 > Install the Flowmark skill with `npx skills add jlevy/flowmark@flowmark` and follow
 > it.
 
-Or run `uvx --from flowmark-rs==0.3.1 flowmark --install-skill` to install the skill
-into `.agents/`, `.claude/`, and `AGENTS.md` directly (see
-[How to Install the Skill](#how-to-install-the-skill)).
+Or install the skill into `.agents/`, `.claude/`, and `AGENTS.md` directly:
+
+```bash
+uvx --from flowmark-rs==0.3.1 flowmark --install-skill
+```
+
+See [How to Install the Skill](#how-to-install-the-skill) for the available surfaces.
 
 For consistency across users and supply chain security, it’s recommended to pin the
 version when installing within a skill or project build.

--- a/docs/e2e-testing.runbook.md
+++ b/docs/e2e-testing.runbook.md
@@ -263,10 +263,10 @@ and agents take.
 
 2. **Version coherence: the pinned release must actually contain this skill.** The
    committed discovery copy pins `uvx --from flowmark==<DISCOVERY_VERSION>`, and
-   `npx skills add jlevy/flowmark` ships that copy to agents who have no other flowmark.
-   So the release `DISCOVERY_VERSION` points at must itself ship the skill behavior the
-   committed copy describes; otherwise an agent reads the new skill text but the pinned
-   binary behaves like an older one.
+   `npx skills add jlevy/flowmark@flowmark` ships that copy to agents who have no other
+   flowmark. So the release `DISCOVERY_VERSION` points at must itself ship the skill
+   behavior the committed copy describes; otherwise an agent reads the new skill text
+   but the pinned binary behaves like an older one.
    New cross-agent features (pinned `uvx` bootstrap, the three install surfaces, format
    stamps) land in commits *after* a tag, so they are absent from any release cut before
    them. Verify the pinned release matches:

--- a/docs/project/specs/active/plan-2026-05-27-cross-agent-skill-support.md
+++ b/docs/project/specs/active/plan-2026-05-27-cross-agent-skill-support.md
@@ -1,12 +1,12 @@
 # Feature: Comprehensive Cross-Agent Skill Support (Self-Documenting, Self-Installing)
 
-**Date:** 2026-05-27 (last updated 2026-05-27)
+**Date:** 2026-05-27 (last updated 2026-07-14)
 
 **Author:** Flowmark maintainers
 
 **Status:** Implemented and merged (PR #49); release-pin hardening and in-repo
-dogfooding follow in PR #53. Will move to `docs/project/specs/done/` after the v0.7.1
-release.
+dogfooding follow in PR #53. A Rust-first repository-migration reference and bundled
+resource installation were added in the `fm-rfnx` follow-up.
 
 ## Overview
 
@@ -14,8 +14,9 @@ Flowmark already ships an agent skill (`src/flowmark/skills/SKILL.md`) and a Cla
 installer (`flowmark --install-skill` writes to a single Claude agent base, default
 `~/.claude`). This spec extends that into **genuine cross-agent** support: one
 `flowmark` invocation installs a portable, self-documenting skill that Claude Code,
-Codex, Gemini CLI, and other agents can discover, plus a public discovery copy so
-`npx skills add jlevy/flowmark` works.
+Codex, Gemini CLI, and other agents can discover, plus a public discovery bundle so
+`npx skills add jlevy/flowmark@flowmark` works without proliferating separate skills for
+formatting and repository setup.
 
 It follows the tbd guideline `cli-agent-skill-patterns` (run
 `tbd guidelines cli-agent-skill-patterns`), verified current against tbd v0.1.30.
@@ -45,9 +46,9 @@ deterministic, formatter-stable output.
   `uvx --from flowmark==<version>`), never an unpinned `@latest` (§6.7, §9; aligns with
   this repo’s `SUPPLY-CHAIN-SECURITY.md`). Also note the Rust port (`flowmark-rs`) as an
   alternative.
-- **Public discovery**: generate a repo-root `skills/flowmark/SKILL.md` from the same
-  source (drift-tested) so `npx skills add jlevy/flowmark` and GitHub skill indexers
-  pick it up (§6.8).
+- **Public discovery**: generate a repo-root `skills/flowmark/` bundle from the same
+  sources (drift-tested) so `npx skills add jlevy/flowmark@flowmark` and GitHub skill
+  indexers pick it up (§6.8).
 - **One source of truth**: every surface (portable, Claude mirror, repo-root discovery
   copy, `AGENTS.md` block) is generated from a single authored body so they cannot
   drift.
@@ -108,7 +109,7 @@ match the `surface=` field on every generated artifact’s format stamp.
     pinned version into the invocation examples.
     Deterministic.
   - `agents_md_block(version) -> str`: the compact marker-bounded block
-    (`<!-- BEGIN FLOWMARK INTEGRATION format=f02 surface=agents-md -->` … `END`),
+    (`<!-- BEGIN FLOWMARK INTEGRATION format=f03 surface=agents-md -->` … `END`),
     emitted in flowmark’s own canonical format so `flowmark --auto` is a no-op on it.
     All generated artifacts (SKILL.md mirrors and this block) share a single
     monotonically-increasing `format=fNN` stamp; the `surface=` field distinguishes
@@ -121,8 +122,11 @@ match the `surface=` field on every generated artifact’s format stamp.
   - A **forward-compatibility guard**: if an existing artifact’s `format=fNN` is newer
     than this build understands, stop and tell the user to upgrade flowmark rather than
     clobber it.
-- **`skills/flowmark/SKILL.md`** (repo root): generated discovery copy for
-  `npx skills add` / indexers, produced from `compose_skill` at build/lint time; opens
+- **`src/flowmark/skills/references/project-setup.md`**: concise repository-adoption
+  guidance for a pinned Rust runner, one project command, `.flowmarkignore`, auto-fixing
+  commit hooks, CI policy, and disabling competing Markdown formatters.
+- **`skills/flowmark/`** (repo root): generated discovery bundle for `npx skills add` /
+  indexers, produced from the authored skill and reference at build/lint time; opens
   with a pinned bootstrap line so a registry install (Markdown only, no binary) still
   works.
 - **CLI (`src/flowmark/cli.py`):** add `--surfaces=<list>`, a comma-separated subset of
@@ -148,9 +152,9 @@ match the `surface=` field on every generated artifact’s format stamp.
 
 ### Generated-Artifact Handling
 
-Use **commit and drift test** (the tbd mode): the authored source lives in
-`src/flowmark/skills/SKILL.md`; the generated `skills/flowmark/SKILL.md` (and any other
-generated surface) is committed and a test regenerates and fails on drift.
+Use **commit and drift test** (the tbd mode): the authored sources live in
+`src/flowmark/skills/`; the generated `skills/flowmark/` bundle (and any other generated
+surface) is committed and a test regenerates and fails on drift.
 Output must be byte-deterministic and flowmark-stable.
 
 ## Implementation Plan
@@ -191,7 +195,19 @@ Output must be byte-deterministic and flowmark-stable.
 - [x] Drift test: regenerate all committed generated artifacts and fail on difference;
   assert `flowmark --auto` over the generated `AGENTS.md` block is a no-op.
 - [x] Update README “Agent Use” section and `docs/` to document cross-agent install and
-  `npx skills add jlevy/flowmark`.
+  `npx skills add jlevy/flowmark@flowmark`.
+
+### Phase 3: Rust-first formatting and repository adoption
+
+- [x] Keep one Flowmark skill and route repository adoption to one bundled reference.
+- [x] Prefer pinned `uvx --from flowmark-rs==<version> flowmark` examples while
+  retaining the Python reference for its library API or newer unported patches.
+- [x] Cover one-file `--auto`, whole-tree migration, `.flowmarkignore`, Makefile wiring,
+  auto-fixing commit hooks, and disabling Prettier or other competing Markdown owners.
+- [x] Make ordinary Markdown formatting a local auto-fix rather than a main-build gate;
+  retain drift checks for generated or byte-exact documentation contracts.
+- [x] Install and forward-compatibility-check the complete skill bundle on portable,
+  Claude, and explicit-base surfaces in both Python and Rust implementations.
 
 ## Testing Strategy
 

--- a/docs/project/specs/active/plan-2026-05-27-cross-agent-skill-support.md
+++ b/docs/project/specs/active/plan-2026-05-27-cross-agent-skill-support.md
@@ -48,10 +48,14 @@ deterministic, formatter-stable output.
   alternative.
 - **Public discovery**: generate a repo-root `skills/flowmark/` bundle from the same
   sources (drift-tested) so `npx skills add jlevy/flowmark@flowmark` and GitHub skill
-  indexers pick it up (§6.8).
+  indexers pick it up (§6.8). The main Flowmark repository is the sole public
+  skill-distribution and documentation source; flowmark-rs provides the recommended
+  executable implementation.
 - **One source of truth**: every surface (portable, Claude mirror, repo-root discovery
   copy, `AGENTS.md` block) is generated from a single authored body so they cannot
-  drift.
+  drift. The Rust port vendors that authored bundle only for `--skill` /
+  `--install-skill` compatibility and tests it byte-for-byte against its pinned Flowmark
+  submodule; it does not publish a second repo-root discovery bundle.
 
 ## Non-Goals
 
@@ -69,6 +73,9 @@ deterministic, formatter-stable output.
 - **Global/user installs by default.** Writing `~/.claude`, `~/.agents/skills/`, etc.
   stays an explicit, separately-flagged action, never something the project-local
   default does silently.
+- **A second public skill bundle in flowmark-rs.** The Rust CLI may install its vendored
+  runtime mirror, but discovery, `npx skills add`, and the main documentation all point
+  to `jlevy/flowmark`.
 
 ## Background
 

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -118,9 +118,10 @@ Follow this checklist for each new release.
 
 5. **Bump the skill’s `uvx` bootstrap pin (one source of truth):**
 
-   The repo-root `skills/flowmark/SKILL.md` (shipped to `npx skills add jlevy/flowmark`
-   users who do *not* have flowmark pre-installed) and the README’s runner examples all
-   pin `uvx --from flowmark==<X.Y.Z>`. That pin must reference a real, PyPI-installable
+   The repo-root `skills/flowmark/SKILL.md` (shipped to
+   `npx skills add jlevy/flowmark@flowmark` users who do *not* have flowmark
+   pre-installed) and the README’s runner examples all pin
+   `uvx --from flowmark==<X.Y.Z>`. That pin must reference a real, PyPI-installable
    release (never a `<version>` placeholder or a `.dev`/local-suffix string), and it
    must be the release you are about to cut, or agents bootstrap a stale flowmark.
 

--- a/docs/shared/flowmark-readme-shared.md
+++ b/docs/shared/flowmark-readme-shared.md
@@ -27,19 +27,17 @@ Both Python and Rust versions are best installed with
 No install needed for one-off usage:
 
 ```shell
-uvx flowmark-rs --help                  # For native-binary Rust
-uvx flowmark-rs --auto somefile.md
-uvx flowmark --help                     # For Python
-uvx flowmark --auto somefile.md
+uvx --from flowmark-rs==__FLOWMARK_RS_VERSION__ flowmark --help
+uvx --from flowmark-rs==__FLOWMARK_RS_VERSION__ flowmark --auto somefile.md
+uvx --from flowmark==__FLOWMARK_VERSION__ flowmark --help  # Python reference
 ```
 
 ### Install as a Global CLI
 
 ```shell
-uv tool install --upgrade flowmark-rs   # For native-binary Rust
-uv tool install --upgrade flowmark      # For Python
-flowmark --auto somefile.md             # One file
-flowmark --auto .                       # Whole tree (respects .gitignore / .flowmarkignore)
+uv tool install flowmark-rs==__FLOWMARK_RS_VERSION__  # Native Rust CLI
+flowmark --auto somefile.md                         # One file
+flowmark --auto .                                   # Whole tree
 ```
 
 Run `flowmark --help`, `flowmark --docs`, or `flowmark --skill` for more.
@@ -49,10 +47,11 @@ Run `flowmark --help`, `flowmark --docs`, or `flowmark --skill` for more.
 Hand your agent this one instruction:
 
 > Set up Flowmark to keep this project’s Markdown auto-formatted.
-> Run `uvx --from flowmark==__FLOWMARK_VERSION__ flowmark --skill` for details.
+> Install the Flowmark skill with `npx skills add jlevy/flowmark@flowmark` and follow
+> it.
 
-Or run `uvx --from flowmark==__FLOWMARK_VERSION__ flowmark --install-skill` to manually
-install the skill into `.agents/`, `.claude/`, and `AGENTS.md` (see
+Or run `uvx --from flowmark-rs==__FLOWMARK_RS_VERSION__ flowmark --install-skill` to
+install the skill into `.agents/`, `.claude/`, and `AGENTS.md` directly (see
 [How to Install the Skill](#how-to-install-the-skill)).
 
 For consistency across users and supply chain security, it’s recommended to pin the
@@ -515,104 +514,20 @@ For batch formatting an entire project, use `flowmark --auto .` from the termina
 
 ## Recommended Project Setup
 
-To keep a repo’s Markdown consistently formatted across contributors and CI, **pin a
-flowmark version** and wire it into your existing build/hook plumbing.
-The same pattern works whether you reach for the Python build or the Rust port.
+Use one pinned Rust command everywhere:
 
-### 1. Pick a pinned invocation
-
-Avoid unpinned `flowmark@latest`: different contributors then silently run different
-versions and produce noisy diffs.
-
-- **Rust port (fastest)**: install the
-  [`flowmark-rs`](https://github.com/jlevy/flowmark-rs) binary at a specific release.
-  Identical formatting to the Python version; great when speed matters in hooks/CI.
-- **Python via `uvx` (zero-install)**: invoke as
-  `uvx --from flowmark==<X.Y.Z> flowmark --auto`. First call caches the wheel;
-  subsequent calls are fast.
-- **Python tool install**: `uv tool install flowmark==<X.Y.Z>` (or
-  `pip install flowmark==<X.Y.Z>` in a venv) puts `flowmark` on `PATH`.
-
-### 2. Add one project entry point
-
-A single command everyone (and CI) runs.
-Makefile target:
-
-```makefile
-FLOWMARK := uvx --from flowmark==__FLOWMARK_VERSION__ flowmark
-
-format-docs:
-	$(FLOWMARK) --auto .
+```bash
+uvx --from flowmark-rs==__FLOWMARK_RS_VERSION__ flowmark --auto .
 ```
 
-Or as an npm script in `package.json`:
+Keep generated, vendored, and byte-exact Markdown in `.flowmarkignore`; disable Markdown
+in Prettier and other competing formatters; and run Flowmark as an auto-fixing commit
+hook. Ordinary Markdown style drift should not fail the main build when the commit hook
+can fix it locally.
 
-```json
-{
-  "scripts": {
-    "format:docs": "uvx --from flowmark==__FLOWMARK_VERSION__ flowmark --auto ."
-  }
-}
-```
-
-### 3. Run on pre-commit
-
-[lefthook](https://lefthook.dev) example (`lefthook.yml`):
-
-```yaml
-pre-commit:
-  commands:
-    flowmark:
-      glob: "*.{md,mdc,markdown}"
-      run: uvx --from flowmark==__FLOWMARK_VERSION__ flowmark --auto {staged_files}
-      stage_fixed: true
-```
-
-Flowmark also ships [pre-commit](https://pre-commit.com) hooks, so you can use it
-directly from your `.pre-commit-config.yaml` without writing a `local` hook:
-
-```yaml
-repos:
-  - repo: https://github.com/jlevy/flowmark
-    rev: v__FLOWMARK_VERSION__
-    hooks:
-      - id: flowmark          # auto-format Markdown in place
-      # - id: flowmark-check  # or: check only, fail if files would change (for CI)
-```
-
-These run via the [pre-commit](https://pre-commit.com) framework (not GitHub-specific):
-install it once with `pre-commit install`, and it builds Flowmark in an isolated
-environment on first use — no global install or extra dependency needed.
-Both hooks pass `--force-exclude`, so your `.flowmarkignore` and other exclusions are
-respected on the staged files pre-commit hands them (the same approach `ruff-pre-commit`
-uses); the `flowmark-check` hook also mirrors `--auto` so it validates exactly what the
-auto-fix hook would write.
-
-A `husky` setup works the same way; the key is the pinned invocation.
-
-### 4. Add a CI check
-
-Use `--check` (or the `flowmark-check` pre-commit hook) to fail if anything would
-change, without writing.
-Pair it with `--auto` so CI validates the same formatting the auto-fix path applies:
-
-```yaml
-- run: uvx --from flowmark==__FLOWMARK_VERSION__ flowmark --auto --check .
-```
-
-### 5. Exclude generated and vendored Markdown
-
-Add a `.flowmarkignore` (same syntax as `.gitignore`) so batch formatting only touches
-files you own:
-
-```
-docs/api/_generated/
-attic/
-third_party/
-```
-
-`flowmark --auto .` always respects `.flowmarkignore` and `.gitignore`. For editor-side
-on-save formatting, see [Use in VSCode/Cursor](#use-in-vscodecursor) above.
+For a migration checklist and copyable Makefile, Lefthook, `pre-commit`, and Prettier
+examples, see
+[Project Setup and Migration](skills/flowmark/references/project-setup.md).
 
 ## Agent Use (Claude Code and Other AI Coding Agents)
 
@@ -637,7 +552,7 @@ copy bootstraps its own pinned `uvx` invocation, so no prior flowmark install is
 required:
 
 ```bash
-npx skills add jlevy/flowmark
+npx skills add jlevy/flowmark@flowmark
 ```
 
 **2. Direct install via the flowmark CLI (recommended once you have flowmark).** Run
@@ -701,8 +616,7 @@ In ephemeral or cloud agent environments where nothing is installed, run it via 
 a newer release):
 
 ```bash
-uvx --from flowmark==<version> flowmark --auto README.md   # Python
-# or use the Rust binary (flowmark-rs) for maximum speed
+uvx --from flowmark-rs==__FLOWMARK_RS_VERSION__ flowmark --auto README.md
 ```
 
 ## How Does Flowmark Compare to Other Markdown Auto-Formatters?

--- a/docs/shared/flowmark-readme-shared.md
+++ b/docs/shared/flowmark-readme-shared.md
@@ -50,9 +50,13 @@ Hand your agent this one instruction:
 > Install the Flowmark skill with `npx skills add jlevy/flowmark@flowmark` and follow
 > it.
 
-Or run `uvx --from flowmark-rs==__FLOWMARK_RS_VERSION__ flowmark --install-skill` to
-install the skill into `.agents/`, `.claude/`, and `AGENTS.md` directly (see
-[How to Install the Skill](#how-to-install-the-skill)).
+Or install the skill into `.agents/`, `.claude/`, and `AGENTS.md` directly:
+
+```bash
+uvx --from flowmark-rs==__FLOWMARK_RS_VERSION__ flowmark --install-skill
+```
+
+See [How to Install the Skill](#how-to-install-the-skill) for the available surfaces.
 
 For consistency across users and supply chain security, it’s recommended to pin the
 version when installing within a skill or project build.

--- a/docs/shared/flowmark-readme-shared.md
+++ b/docs/shared/flowmark-readme-shared.md
@@ -545,11 +545,15 @@ own.
 
 ### How to Install the Skill
 
+The main [Flowmark repository](https://github.com/jlevy/flowmark) owns the public skill
+bundle and its documentation.
+The Rust repository supplies the recommended fast implementation, not a second skill
+distribution.
+
 There are three install paths, ordered by what most users want first:
 
-**1. Cross-agent package manager (no flowmark prerequisite).** If you just want the
-skill on disk for any supported agent and don’t already have flowmark, use the
-`skills.sh` installer.
+**1. Install from the main Flowmark repository (recommended).** If you just want the
+skill on disk for any supported agent, use the `skills.sh` installer.
 It copies the published discovery copy into `.agents/skills/` and symlinks it into each
 agent’s native location (Claude Code, Codex, Cursor, Copilot, Gemini, …). The discovery
 copy bootstraps its own pinned `uvx` invocation, so no prior flowmark install is
@@ -559,8 +563,9 @@ required:
 npx skills add jlevy/flowmark@flowmark
 ```
 
-**2. Direct install via the flowmark CLI (recommended once you have flowmark).** Run
-from the repo root.
+**2. Direct install via either flowmark CLI.** Run from the repo root.
+The Python and Rust CLIs install the same skill bundle; this path is useful when either
+implementation is already available.
 By default this writes all three project-local surfaces: the portable
 `.agents/skills/flowmark/` (read by Codex, Gemini CLI, pi, and others), the
 `.claude/skills/flowmark/` mirror (Claude Code reads only that path), and a compact

--- a/scripts/generate-python-readme.py
+++ b/scripts/generate-python-readme.py
@@ -17,15 +17,15 @@ from pathlib import Path
 from jinja2 import Environment, StrictUndefined
 from strif import atomic_output_file
 
-# Runner-pin placeholder used in the shared docs body (and the authored SKILL.md):
-# `uvx --from flowmark==__FLOWMARK_VERSION__ flowmark`. Substituted here with the single
-# source of truth, DISCOVERY_VERSION in src/flowmark/skill.py, so every shipped example
-# pins the same real release and a release bump only has to touch one constant.
+# Runner-pin placeholders used in the shared docs body and authored skill.
+# Substitute both from the discovery constants in src/flowmark/skill.py so the README,
+# published skill bundle, and installed mirrors stay pinned to the same releases.
 VERSION_PLACEHOLDER = "__FLOWMARK_VERSION__"
+RS_VERSION_PLACEHOLDER = "__FLOWMARK_RS_VERSION__"
 
 
-def read_discovery_version(repo_root: Path) -> str:
-    """Read DISCOVERY_VERSION (the canonical release pin) from src/flowmark/skill.py.
+def read_discovery_versions(repo_root: Path) -> tuple[str, str]:
+    """Read the Python and Rust-port release pins from src/flowmark/skill.py.
 
     This standalone script runs on its own interpreter without flowmark importable, so
     parse the constant out of source rather than importing it. One source of truth means
@@ -33,15 +33,15 @@ def read_discovery_version(repo_root: Path) -> str:
     uses.
     """
     skill_py = repo_root / "src" / "flowmark" / "skill.py"
-    match = re.search(
-        r'^DISCOVERY_VERSION\s*=\s*"([^"]+)"', skill_py.read_text(encoding="utf-8"), re.M
-    )
-    if not match:
-        raise ValueError(f"could not find DISCOVERY_VERSION in {skill_py}")
-    return match.group(1)
+    source = skill_py.read_text(encoding="utf-8")
+    python_match = re.search(r'^DISCOVERY_VERSION\s*=\s*"([^"]+)"', source, re.M)
+    rust_match = re.search(r'^FLOWMARK_RS_DISCOVERY_VERSION\s*=\s*"([^"]+)"', source, re.M)
+    if not python_match or not rust_match:
+        raise ValueError(f"could not find discovery versions in {skill_py}")
+    return python_match.group(1), rust_match.group(1)
 
 
-def parse_args() -> tuple[Path, Path, Path, str]:
+def parse_args() -> tuple[Path, Path, Path, str, str]:
     """Parse arguments and resolve default repo-relative paths."""
     repo_root = Path(__file__).resolve().parents[1]
     parser = ArgumentParser(description="Generate README.md from Python wrapper + shared docs.")
@@ -69,9 +69,17 @@ def parse_args() -> tuple[Path, Path, Path, str]:
         help="Version substituted for the runner-pin placeholder "
         "(default: DISCOVERY_VERSION from src/flowmark/skill.py).",
     )
+    parser.add_argument(
+        "--flowmark-rs-version",
+        default=None,
+        help="Rust-port version substituted for the runner-pin placeholder "
+        "(default: FLOWMARK_RS_DISCOVERY_VERSION from src/flowmark/skill.py).",
+    )
     args = parser.parse_args()
-    version = args.flowmark_version or read_discovery_version(repo_root)
-    return args.shared_docs, args.template, args.output, version
+    python_default, rust_default = read_discovery_versions(repo_root)
+    python_version = args.flowmark_version or python_default
+    rust_version = args.flowmark_rs_version or rust_default
+    return args.shared_docs, args.template, args.output, python_version, rust_version
 
 
 def render_readme(template_path: Path, shared_docs_body: str) -> str:
@@ -96,7 +104,7 @@ def write_atomic(output_path: Path, content: str) -> None:
 
 def main() -> int:
     """Generate README.md from shared docs and wrapper template."""
-    shared_docs_path, template_path, output_path, version = parse_args()
+    shared_docs_path, template_path, output_path, version, rs_version = parse_args()
 
     if not shared_docs_path.exists():
         raise FileNotFoundError(f"missing shared docs source at {shared_docs_path}")
@@ -106,12 +114,15 @@ def main() -> int:
     shared_docs_body = shared_docs_path.read_text(encoding="utf-8")
     rendered = render_readme(template_path, shared_docs_body)
     rendered = rendered.replace(VERSION_PLACEHOLDER, version)
-    if VERSION_PLACEHOLDER in rendered:
-        raise ValueError(f"{VERSION_PLACEHOLDER} still present after substitution")
+    rendered = rendered.replace(RS_VERSION_PLACEHOLDER, rs_version)
+    for placeholder in (VERSION_PLACEHOLDER, RS_VERSION_PLACEHOLDER):
+        if placeholder in rendered:
+            raise ValueError(f"{placeholder} still present after substitution")
     write_atomic(output_path, rendered)
 
     print(f"Generated {output_path} from {shared_docs_path} via {template_path}")
     print(f"Pinned runner examples to flowmark=={version}")
+    print(f"Pinned runner examples to flowmark-rs=={rs_version}")
     return 0
 
 

--- a/scripts/generate-skill-discovery.py
+++ b/scripts/generate-skill-discovery.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 """
-Generate the committed repo-root skill discovery copy at `skills/flowmark/SKILL.md`.
+Generate the committed repo-root skill bundle under `skills/flowmark/`.
 
-This is the published landing-page skill that `npx skills add jlevy/flowmark` and skill
-indexers pick up. It is generated from the same authored source as the installed skill
-(`flowmark.skill.discovery_skill_text`) so the two can't drift; `tests/test_skill_artifacts.py`
-fails if the committed copy is stale.
+This is the published landing-page skill that
+`npx skills add jlevy/flowmark@flowmark` and skill indexers pick up. It is generated from
+the same authored source as the installed skill (`flowmark.skill.discovery_skill_text`)
+so the two can't drift; `tests/test_skill_artifacts.py` fails if the committed copy is
+stale.
 """
 
 from __future__ import annotations
@@ -14,14 +15,19 @@ from pathlib import Path
 
 from strif import atomic_output_file
 
-from flowmark.skill import discovery_skill_text
+from flowmark.skill import discovery_project_setup_text, discovery_skill_text
 
 
 def main() -> None:
-    output = Path(__file__).resolve().parents[1] / "skills" / "flowmark" / "SKILL.md"
-    with atomic_output_file(output, make_parents=True) as tmp:
+    skill_dir = Path(__file__).resolve().parents[1] / "skills" / "flowmark"
+    skill_output = skill_dir / "SKILL.md"
+    reference_output = skill_dir / "references" / "project-setup.md"
+    with atomic_output_file(skill_output, make_parents=True) as tmp:
         Path(tmp).write_text(discovery_skill_text(), encoding="utf-8")
-    print(f"Generated {output}")
+    with atomic_output_file(reference_output, make_parents=True) as tmp:
+        Path(tmp).write_text(discovery_project_setup_text(), encoding="utf-8")
+    print(f"Generated {skill_output}")
+    print(f"Generated {reference_output}")
 
 
 if __name__ == "__main__":

--- a/skills/flowmark/SKILL.md
+++ b/skills/flowmark/SKILL.md
@@ -40,8 +40,10 @@ uvx --from flowmark==0.7.2 flowmark --auto FILE
 
 ## Adopt Flowmark in a Repository
 
-For a repository-wide migration, Makefile wiring, `.flowmarkignore`, commit hooks, CI
-policy, and disabling Prettier or other competing Markdown formatters, read
+If this skill came from `flowmark --skill`, run the same runner with `--install-skill`
+from the project root to materialize the complete bundle.
+Then, for a repository-wide migration, Makefile wiring, `.flowmarkignore`, commit hooks,
+CI policy, and disabling Prettier or other competing Markdown formatters, read
 [project-setup.md](references/project-setup.md) in full before editing.
 
 ## Full Documentation

--- a/skills/flowmark/SKILL.md
+++ b/skills/flowmark/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: flowmark
-description: Fast, consistent Markdown auto-formatter for typographic cleanup (smart quotes, ellipses), normalized formatting, and optional clean line wrapping for small, readable git diffs. Use when creating, editing, or normalizing Markdown (.md) files, cleaning up LLM-generated Markdown, or when the user mentions flowmark or formatting Markdown.
+description: Fast, consistent Markdown auto-formatter for typographic cleanup, normalization, and clean semantic line breaks. Use when creating, editing, or cleaning Markdown; formatting LLM-generated docs; adopting Flowmark in a repository; adding Markdown format scripts or commit hooks; or replacing Prettier or another Markdown formatter.
 allowed-tools: Bash(flowmark:*), Bash(uvx:*), Read, Write
 ---
-<!-- DO NOT EDIT: `flowmark --install-skill` (format=f02 surface=skill-md) -->
+<!-- DO NOT EDIT: `flowmark --install-skill` (format=f03 surface=skill-md) -->
 
 # Flowmark - Markdown Auto-Formatter
 
@@ -12,7 +12,7 @@ Run it on Markdown you generate or edit so committed diffs stay small and readab
 It is conservative and safe to run on every file: it never modifies code blocks or
 inline code.
 
-## Default Usage
+## Format Markdown
 
 Format in place with all auto-formatting (typography, cleanups, semantic line breaks):
 
@@ -23,26 +23,26 @@ flowmark --auto .      # whole tree (respects .gitignore and .flowmarkignore)
 
 Omit `--auto` to preview to stdout; pipe stdin with `-` (e.g. `cat FILE | flowmark -`).
 
-Flowmark ships as two packages with identical formatting and the same `flowmark`
-command: the fast native Rust port [`flowmark-rs`](https://github.com/jlevy/flowmark-rs)
-(recommended) and the Python reference [`flowmark`](https://github.com/jlevy/flowmark).
-Prefer flowmark-rs; reach for the Python build only when you need its library API or the
-very latest patch release not yet ported to Rust.
-If `flowmark` is not on `PATH`, run it with a version-pinned runner (never `@latest`):
+Use `flowmark` when it is already on `PATH`. Otherwise use the fast
+[Rust port](https://github.com/jlevy/flowmark-rs) with a version-pinned `uvx` runner
+(never `@latest`):
 
 ```bash
-# Recommended: fast native Rust port
-uvx --from flowmark-rs==0.3.0 flowmark --auto FILE
-# Python reference (library API or newest patch releases)
+uvx --from flowmark-rs==0.3.1 flowmark --auto FILE
+```
+
+The [Python reference](https://github.com/jlevy/flowmark) remains available when its
+library API or a newer unported patch is required:
+
+```bash
 uvx --from flowmark==0.7.2 flowmark --auto FILE
 ```
 
-## When to Use It
+## Adopt Flowmark in a Repository
 
-- Auto-format Markdown you create or edit, before committing.
-- Normalize and clean up LLM-generated Markdown.
-- Typographic cleanup (smart quotes, ellipses) and consistent formatting.
-- Optional semantic (sentence-based) line breaks for cleaner git diffs (`--semantic`).
+For a repository-wide migration, Makefile wiring, `.flowmarkignore`, commit hooks, CI
+policy, and disabling Prettier or other competing Markdown formatters, read
+[project-setup.md](references/project-setup.md) in full before editing.
 
 ## Full Documentation
 
@@ -52,9 +52,8 @@ Use the CLI rather than reproducing details here:
 - `flowmark --help` — every flag: `--semantic`, `--smartquotes`, `--ellipses`,
   `--width`, `--check`, list spacing, and file discovery
   (`--extend-include`/`--extend-exclude`).
-- `flowmark --docs` — the full guide: editor on-save setup (VS Code/Cursor), project
-  wiring (pre-commit/CI, `.flowmarkignore`), config files, the Python library API, and
-  installing this skill for other agents (`flowmark --install-skill`).
+- `flowmark --docs` — the full guide: configuration, file discovery, editor setup, the
+  Python library API, and installing this skill (`flowmark --install-skill`).
 
 <!-- This document follows common-doc-guidelines.md.
 See github.com/jlevy/practical-prose and review guidelines before editing.

--- a/skills/flowmark/references/project-setup.md
+++ b/skills/flowmark/references/project-setup.md
@@ -62,7 +62,7 @@ Lefthook can format and stage Markdown without turning style into a separate fai
 pre-commit:
   commands:
     flowmark:
-      glob: "*.md"
+      glob: "*.{md,mdc,markdown}"
       run: uvx --from flowmark-rs==0.3.1 flowmark --auto --force-exclude {staged_files}
       stage_fixed: true
 ```
@@ -81,12 +81,13 @@ repos:
         name: flowmark
         entry: uvx --from flowmark-rs==0.3.1 flowmark --auto --force-exclude
         language: system
-        types: [markdown]
+        files: '\.(md|mdc|markdown)$'
 ```
 
-The `pre-commit` framework stops the first commit after modifying files; stage the fixes
-and retry. Use Lefthook with `stage_fixed: true` when transparent auto-staging is
-preferred.
+Keep both hook selectors aligned with any Markdown extensions the repository discovers
+through `--extend-include`. The `pre-commit` framework stops the first commit after
+modifying files; stage the fixes and retry.
+Use Lefthook with `stage_fixed: true` when transparent auto-staging is preferred.
 
 ## Disable Competing Markdown Formatters
 

--- a/skills/flowmark/references/project-setup.md
+++ b/skills/flowmark/references/project-setup.md
@@ -1,0 +1,110 @@
+<!-- DO NOT EDIT: `flowmark --install-skill` (format=f03 surface=skill-reference) -->
+
+# Project Setup and Migration
+
+Use this workflow when adopting Flowmark across a repository.
+Keep one `flowmark` skill; project setup is a use case of that skill, not a separate
+skill.
+
+## Migration Checklist
+
+1. Find the Markdown sources and identify generated, vendored, fixture, and golden files
+   that must retain byte-exact content.
+2. Add those paths to `.flowmarkignore`.
+3. Make Flowmark the only formatter that owns Markdown.
+   Disable Markdown in Prettier, Biome, dprint, editor format-on-save settings, and
+   existing Markdown hooks.
+4. Add one pinned project command and run it once over the repository.
+   Review and commit the baseline reformat separately from content changes.
+5. Add an auto-fixing commit hook.
+   Prefer a hook that stages its fixes so formatting does not become a manual gate.
+6. Do not fail the main build only for ordinary Markdown formatting drift.
+   Keep formatting local and automatic; reserve CI drift checks for generated or
+   contractually byte-exact documentation.
+
+## Pinned Project Command
+
+Prefer the Rust port through `uvx`:
+
+```makefile
+FLOWMARK := uvx --from flowmark-rs==0.3.1 flowmark
+
+.PHONY: format-docs
+format-docs:
+	$(FLOWMARK) --auto .
+```
+
+Passing `.` lets Flowmark discover files once and honor `.gitignore` and
+`.flowmarkignore` from the repository root.
+Avoid shell `find` pipelines or per-directory invocations unless the repository requires
+them.
+
+Start `.flowmarkignore` with content Flowmark must not rewrite:
+
+```gitignore
+# Generated or vendored Markdown
+docs/api/_generated/
+third_party/
+
+# Byte-exact fixtures and golden files
+tests/fixtures/
+tests/golden/
+```
+
+When documentation is generated, format canonical sources first, then regenerate their
+mirrors. Exclude generated mirrors from Flowmark so there is one source of truth.
+
+## Auto-Fix on Commit
+
+Lefthook can format and stage Markdown without turning style into a separate failure:
+
+```yaml
+pre-commit:
+  commands:
+    flowmark:
+      glob: "*.md"
+      run: uvx --from flowmark-rs==0.3.1 flowmark --auto --force-exclude {staged_files}
+      stage_fixed: true
+```
+
+`--force-exclude` applies `.flowmarkignore` even though the hook passes explicit file
+paths. If generated docs must be refreshed after formatting, call one repository script
+or Make target that performs both operations in the required order.
+
+For the `pre-commit` framework, use a local system hook with the same pinned command:
+
+```yaml
+repos:
+  - repo: local
+    hooks:
+      - id: flowmark
+        name: flowmark
+        entry: uvx --from flowmark-rs==0.3.1 flowmark --auto --force-exclude
+        language: system
+        types: [markdown]
+```
+
+The `pre-commit` framework stops the first commit after modifying files; stage the fixes
+and retry. Use Lefthook with `stage_fixed: true` when transparent auto-staging is
+preferred.
+
+## Disable Competing Markdown Formatters
+
+For Prettier, exclude Markdown in `.prettierignore`:
+
+```gitignore
+*.md
+```
+
+Also remove Markdown-specific Prettier hooks and editor defaults.
+If Flowmark owns MDX or another extension via `--extend-include`, exclude that extension
+from Prettier too.
+
+Apply the same ownership rule to other tools: keep them for code and data formats, but
+remove Markdown from their include globs and format-on-save configuration.
+Do not run two Markdown formatters sequentially; they can churn each other’s output and
+make hooks or CI nondeterministic.
+
+<!-- This document follows common-doc-guidelines.md.
+See github.com/jlevy/practical-prose and review guidelines before editing.
+-->

--- a/src/flowmark/skill.py
+++ b/src/flowmark/skill.py
@@ -23,7 +23,7 @@ from strif import atomic_output_file
 # which artifact. Bump this whenever the shape of any generated artifact changes —
 # a future flowmark uses the stamp to detect older shapes and safely upgrade them
 # (and refuses to clobber a newer format it doesn't understand).
-FLOWMARK_FORMAT = "f02"
+FLOWMARK_FORMAT = "f03"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # CROSS-IMPLEMENTATION PORTING CONTRACT (read before porting to flowmark-rs)
@@ -61,7 +61,7 @@ _VERSION_PLACEHOLDER = "__FLOWMARK_VERSION__"  # this package (flowmark, Python)
 _RS_VERSION_PLACEHOLDER = "__FLOWMARK_RS_VERSION__"  # sibling Rust port (flowmark-rs)
 
 # Concrete released-version pin baked into the committed repo-root discovery copy
-# (`skills/flowmark/SKILL.md`), the artifact `npx skills add jlevy/flowmark` and
+# (`skills/flowmark/SKILL.md`), the artifact `npx skills add jlevy/flowmark@flowmark` and
 # skill indexers consume without flowmark needing to be pre-installed. Must be a
 # real, PyPI-installable version — never a `<version>` placeholder or a `.dev`/
 # local-suffix string — so the bootstrap `uvx --from flowmark==<X.Y.Z>` example
@@ -80,7 +80,7 @@ DISCOVERY_VERSION = "0.7.2"
 # `uvx --from flowmark-rs==<X.Y.Z> flowmark` bootstrap actually resolves.
 # Rust port: roles swap — the port pins flowmark-rs dynamically (its own build) and keeps
 # a sibling flowmark (Python) discovery constant here instead. See the porting contract.
-FLOWMARK_RS_DISCOVERY_VERSION = "0.3.0"
+FLOWMARK_RS_DISCOVERY_VERSION = "0.3.1"
 
 
 def get_skill_content() -> str:
@@ -99,6 +99,14 @@ def get_skill_content() -> str:
 
     skill_file = files("flowmark").joinpath("skills/SKILL.md")
     return skill_file.read_text(encoding="utf-8")
+
+
+def get_project_setup_content() -> str:
+    """Read the authored project-setup reference from package data."""
+    from importlib.resources import files
+
+    reference_file = files("flowmark").joinpath("skills/references/project-setup.md")
+    return reference_file.read_text(encoding="utf-8")
 
 
 # An exact-pinnable published PyPI release: a plain release segment (digits and
@@ -161,6 +169,12 @@ def compose_skill(version: str | None = None) -> str:
     )
 
 
+def compose_project_setup(rs_version: str | None = None) -> str:
+    """Render the project-setup reference with a concrete Rust-port runner pin."""
+    pin = FLOWMARK_RS_DISCOVERY_VERSION if rs_version is None else rs_version
+    return get_project_setup_content().replace(_RS_VERSION_PLACEHOLDER, pin)
+
+
 def get_docs_content() -> str:
     """Read README.md from the repository root.
 
@@ -204,9 +218,12 @@ def _format_num() -> int:
     return int(FLOWMARK_FORMAT.lstrip("f"))
 
 
-def _generated_marker() -> str:
+def _generated_marker(surface: str) -> str:
     # No internal `.` so flowmark’s sentence-wrap leaves the line intact.
-    return f"<!-- DO NOT EDIT: `flowmark --install-skill` (format={FLOWMARK_FORMAT} surface=skill-md) -->"
+    return (
+        "<!-- DO NOT EDIT: `flowmark --install-skill` "
+        f"(format={FLOWMARK_FORMAT} surface={surface}) -->"
+    )
 
 
 def render_skill_file(version: str | None = None) -> str:
@@ -216,13 +233,19 @@ def render_skill_file(version: str | None = None) -> str:
     first and the marker survives a `flowmark --auto` pass).
     """
     composed = compose_skill(version)
-    marker = _generated_marker()
+    marker = _generated_marker("skill-md")
     delimiter = "\n---\n"
     if composed.startswith("---\n") and (end := composed.find(delimiter, 4)) != -1:
         head = composed[: end + len(delimiter)]
         body = composed[end + len(delimiter) :]
         return f"{head}{marker}\n\n{body}"
     return f"{marker}\n\n{composed}"
+
+
+def render_project_setup_file(rs_version: str | None = None) -> str:
+    """Render the generated project-setup reference installed beside `SKILL.md`."""
+    marker = _generated_marker("skill-reference")
+    return f"{marker}\n\n{compose_project_setup(rs_version)}"
 
 
 def discovery_skill_text() -> str:
@@ -234,6 +257,11 @@ def discovery_skill_text() -> str:
     Install-time copies, by contrast, pin to the actually-installed version.
     """
     return render_skill_file(DISCOVERY_VERSION)
+
+
+def discovery_project_setup_text() -> str:
+    """The reference bundled with the committed `skills/flowmark/` discovery skill."""
+    return render_project_setup_file(FLOWMARK_RS_DISCOVERY_VERSION)
 
 
 def _existing_format(path: Path) -> int | None:
@@ -337,17 +365,32 @@ def update_agents_md(path: Path, version: str | None = None) -> InstallResult:
     return InstallResult(surface, path, action)
 
 
-def _write_surface(skill_dir: Path, surface: str, content: str) -> InstallResult:
+def _write_surface(
+    skill_dir: Path,
+    surface: str,
+    content: str,
+    project_setup_content: str,
+) -> InstallResult:
     target = skill_dir / "SKILL.md"
-    existing = _existing_format(target)
+    project_setup_target = skill_dir / "references" / "project-setup.md"
+    existing_formats = [_existing_format(target), _existing_format(project_setup_target)]
     # Forward-compatibility guard: never clobber an artifact stamped with a newer format.
-    if existing is not None and existing > _format_num():
+    if any(existing is not None and existing > _format_num() for existing in existing_formats):
         return InstallResult(surface, target, "blocked-newer")
-    if target.is_file() and target.read_text(encoding="utf-8") == content:
+    skill_matches = target.is_file() and target.read_text(encoding="utf-8") == content
+    reference_matches = (
+        project_setup_target.is_file()
+        and project_setup_target.read_text(encoding="utf-8") == project_setup_content
+    )
+    if skill_matches and reference_matches:
         return InstallResult(surface, target, "unchanged")
-    action = "updated" if target.exists() else "installed"
-    with atomic_output_file(target, make_parents=True) as tmp:
-        Path(tmp).write_text(content, encoding="utf-8")
+    action = "updated" if target.exists() or project_setup_target.exists() else "installed"
+    if not skill_matches:
+        with atomic_output_file(target, make_parents=True) as tmp:
+            Path(tmp).write_text(content, encoding="utf-8")
+    if not reference_matches:
+        with atomic_output_file(project_setup_target, make_parents=True) as tmp:
+            Path(tmp).write_text(project_setup_content, encoding="utf-8")
     return InstallResult(surface, target, action)
 
 
@@ -373,6 +416,7 @@ def install_skill(
     """
     try:
         content = render_skill_file()
+        project_setup_content = render_project_setup_file()
     except (ImportError, FileNotFoundError) as e:
         print(f"\n✗ Error: Could not load skill content: {e}", file=sys.stderr)
         print("\nThis command requires flowmark to be installed as a package.", file=sys.stderr)
@@ -388,19 +432,36 @@ def install_skill(
     try:
         if agent_base is not None:
             base = Path(agent_base).resolve()
-            results.append(_write_surface(base / "skills" / SKILL_DIRNAME, str(base), content))
+            results.append(
+                _write_surface(
+                    base / "skills" / SKILL_DIRNAME,
+                    str(base),
+                    content,
+                    project_setup_content,
+                )
+            )
         else:
             root = Path(project_root).resolve() if project_root is not None else Path.cwd()
             project_local_root = root
             if SURFACE_PORTABLE in selected:
                 results.append(
-                    _write_surface(root / PORTABLE_SKILL_REL, ".agents/skills (portable)", content)
+                    _write_surface(
+                        root / PORTABLE_SKILL_REL,
+                        ".agents/skills (portable)",
+                        content,
+                        project_setup_content,
+                    )
                 )
             if SURFACE_AGENTS_MD in selected:
                 results.append(update_agents_md(root / "AGENTS.md"))
             if SURFACE_CLAUDE in selected:
                 results.append(
-                    _write_surface(root / CLAUDE_SKILL_REL, ".claude/skills (Claude Code)", content)
+                    _write_surface(
+                        root / CLAUDE_SKILL_REL,
+                        ".claude/skills (Claude Code)",
+                        content,
+                        project_setup_content,
+                    )
                 )
     except PermissionError as e:
         print(f"\n✗ Permission denied: {e}", file=sys.stderr)

--- a/src/flowmark/skill.py
+++ b/src/flowmark/skill.py
@@ -373,10 +373,11 @@ def _write_surface(
 ) -> InstallResult:
     target = skill_dir / "SKILL.md"
     project_setup_target = skill_dir / "references" / "project-setup.md"
-    existing_formats = [_existing_format(target), _existing_format(project_setup_target)]
     # Forward-compatibility guard: never clobber an artifact stamped with a newer format.
-    if any(existing is not None and existing > _format_num() for existing in existing_formats):
-        return InstallResult(surface, target, "blocked-newer")
+    for artifact in (target, project_setup_target):
+        existing_format = _existing_format(artifact)
+        if existing_format is not None and existing_format > _format_num():
+            return InstallResult(surface, artifact, "blocked-newer")
     skill_matches = target.is_file() and target.read_text(encoding="utf-8") == content
     reference_matches = (
         project_setup_target.is_file()

--- a/src/flowmark/skill.py
+++ b/src/flowmark/skill.py
@@ -386,12 +386,19 @@ def _write_surface(
     if skill_matches and reference_matches:
         return InstallResult(surface, target, "unchanged")
     action = "updated" if target.exists() or project_setup_target.exists() else "installed"
-    if not skill_matches:
-        with atomic_output_file(target, make_parents=True) as tmp:
-            Path(tmp).write_text(content, encoding="utf-8")
-    if not reference_matches:
+    if not skill_matches and not reference_matches:
+        # Stage both files, then publish the reference first so SKILL.md never links to
+        # an artifact that failed to materialize.
+        with atomic_output_file(target, make_parents=True) as skill_tmp:
+            Path(skill_tmp).write_text(content, encoding="utf-8")
+            with atomic_output_file(project_setup_target, make_parents=True) as reference_tmp:
+                Path(reference_tmp).write_text(project_setup_content, encoding="utf-8")
+    elif not reference_matches:
         with atomic_output_file(project_setup_target, make_parents=True) as tmp:
             Path(tmp).write_text(project_setup_content, encoding="utf-8")
+    elif not skill_matches:
+        with atomic_output_file(target, make_parents=True) as tmp:
+            Path(tmp).write_text(content, encoding="utf-8")
     return InstallResult(surface, target, action)
 
 

--- a/src/flowmark/skills/SKILL.md
+++ b/src/flowmark/skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: flowmark
-description: Fast, consistent Markdown auto-formatter for typographic cleanup (smart quotes, ellipses), normalized formatting, and optional clean line wrapping for small, readable git diffs. Use when creating, editing, or normalizing Markdown (.md) files, cleaning up LLM-generated Markdown, or when the user mentions flowmark or formatting Markdown.
+description: Fast, consistent Markdown auto-formatter for typographic cleanup, normalization, and clean semantic line breaks. Use when creating, editing, or cleaning Markdown; formatting LLM-generated docs; adopting Flowmark in a repository; adding Markdown format scripts or commit hooks; or replacing Prettier or another Markdown formatter.
 allowed-tools: Bash(flowmark:*), Bash(uvx:*), Read, Write
 ---
 # Flowmark - Markdown Auto-Formatter
@@ -10,7 +10,7 @@ Run it on Markdown you generate or edit so committed diffs stay small and readab
 It is conservative and safe to run on every file: it never modifies code blocks or
 inline code.
 
-## Default Usage
+## Format Markdown
 
 Format in place with all auto-formatting (typography, cleanups, semantic line breaks):
 
@@ -21,26 +21,26 @@ flowmark --auto .      # whole tree (respects .gitignore and .flowmarkignore)
 
 Omit `--auto` to preview to stdout; pipe stdin with `-` (e.g. `cat FILE | flowmark -`).
 
-Flowmark ships as two packages with identical formatting and the same `flowmark`
-command: the fast native Rust port [`flowmark-rs`](https://github.com/jlevy/flowmark-rs)
-(recommended) and the Python reference [`flowmark`](https://github.com/jlevy/flowmark).
-Prefer flowmark-rs; reach for the Python build only when you need its library API or the
-very latest patch release not yet ported to Rust.
-If `flowmark` is not on `PATH`, run it with a version-pinned runner (never `@latest`):
+Use `flowmark` when it is already on `PATH`. Otherwise use the fast
+[Rust port](https://github.com/jlevy/flowmark-rs) with a version-pinned `uvx` runner
+(never `@latest`):
 
 ```bash
-# Recommended: fast native Rust port
 uvx --from flowmark-rs==__FLOWMARK_RS_VERSION__ flowmark --auto FILE
-# Python reference (library API or newest patch releases)
+```
+
+The [Python reference](https://github.com/jlevy/flowmark) remains available when its
+library API or a newer unported patch is required:
+
+```bash
 uvx --from flowmark==__FLOWMARK_VERSION__ flowmark --auto FILE
 ```
 
-## When to Use It
+## Adopt Flowmark in a Repository
 
-- Auto-format Markdown you create or edit, before committing.
-- Normalize and clean up LLM-generated Markdown.
-- Typographic cleanup (smart quotes, ellipses) and consistent formatting.
-- Optional semantic (sentence-based) line breaks for cleaner git diffs (`--semantic`).
+For a repository-wide migration, Makefile wiring, `.flowmarkignore`, commit hooks, CI
+policy, and disabling Prettier or other competing Markdown formatters, read
+[project-setup.md](references/project-setup.md) in full before editing.
 
 ## Full Documentation
 
@@ -50,9 +50,8 @@ Use the CLI rather than reproducing details here:
 - `flowmark --help` — every flag: `--semantic`, `--smartquotes`, `--ellipses`,
   `--width`, `--check`, list spacing, and file discovery
   (`--extend-include`/`--extend-exclude`).
-- `flowmark --docs` — the full guide: editor on-save setup (VS Code/Cursor), project
-  wiring (pre-commit/CI, `.flowmarkignore`), config files, the Python library API, and
-  installing this skill for other agents (`flowmark --install-skill`).
+- `flowmark --docs` — the full guide: configuration, file discovery, editor setup, the
+  Python library API, and installing this skill (`flowmark --install-skill`).
 
 <!-- This document follows common-doc-guidelines.md.
 See github.com/jlevy/practical-prose and review guidelines before editing.

--- a/src/flowmark/skills/SKILL.md
+++ b/src/flowmark/skills/SKILL.md
@@ -38,8 +38,10 @@ uvx --from flowmark==__FLOWMARK_VERSION__ flowmark --auto FILE
 
 ## Adopt Flowmark in a Repository
 
-For a repository-wide migration, Makefile wiring, `.flowmarkignore`, commit hooks, CI
-policy, and disabling Prettier or other competing Markdown formatters, read
+If this skill came from `flowmark --skill`, run the same runner with `--install-skill`
+from the project root to materialize the complete bundle.
+Then, for a repository-wide migration, Makefile wiring, `.flowmarkignore`, commit hooks,
+CI policy, and disabling Prettier or other competing Markdown formatters, read
 [project-setup.md](references/project-setup.md) in full before editing.
 
 ## Full Documentation

--- a/src/flowmark/skills/references/project-setup.md
+++ b/src/flowmark/skills/references/project-setup.md
@@ -60,7 +60,7 @@ Lefthook can format and stage Markdown without turning style into a separate fai
 pre-commit:
   commands:
     flowmark:
-      glob: "*.md"
+      glob: "*.{md,mdc,markdown}"
       run: uvx --from flowmark-rs==__FLOWMARK_RS_VERSION__ flowmark --auto --force-exclude {staged_files}
       stage_fixed: true
 ```
@@ -79,12 +79,13 @@ repos:
         name: flowmark
         entry: uvx --from flowmark-rs==__FLOWMARK_RS_VERSION__ flowmark --auto --force-exclude
         language: system
-        types: [markdown]
+        files: '\.(md|mdc|markdown)$'
 ```
 
-The `pre-commit` framework stops the first commit after modifying files; stage the fixes
-and retry. Use Lefthook with `stage_fixed: true` when transparent auto-staging is
-preferred.
+Keep both hook selectors aligned with any Markdown extensions the repository discovers
+through `--extend-include`. The `pre-commit` framework stops the first commit after
+modifying files; stage the fixes and retry.
+Use Lefthook with `stage_fixed: true` when transparent auto-staging is preferred.
 
 ## Disable Competing Markdown Formatters
 

--- a/src/flowmark/skills/references/project-setup.md
+++ b/src/flowmark/skills/references/project-setup.md
@@ -1,0 +1,108 @@
+# Project Setup and Migration
+
+Use this workflow when adopting Flowmark across a repository.
+Keep one `flowmark` skill; project setup is a use case of that skill, not a separate
+skill.
+
+## Migration Checklist
+
+1. Find the Markdown sources and identify generated, vendored, fixture, and golden files
+   that must retain byte-exact content.
+2. Add those paths to `.flowmarkignore`.
+3. Make Flowmark the only formatter that owns Markdown.
+   Disable Markdown in Prettier, Biome, dprint, editor format-on-save settings, and
+   existing Markdown hooks.
+4. Add one pinned project command and run it once over the repository.
+   Review and commit the baseline reformat separately from content changes.
+5. Add an auto-fixing commit hook.
+   Prefer a hook that stages its fixes so formatting does not become a manual gate.
+6. Do not fail the main build only for ordinary Markdown formatting drift.
+   Keep formatting local and automatic; reserve CI drift checks for generated or
+   contractually byte-exact documentation.
+
+## Pinned Project Command
+
+Prefer the Rust port through `uvx`:
+
+```makefile
+FLOWMARK := uvx --from flowmark-rs==__FLOWMARK_RS_VERSION__ flowmark
+
+.PHONY: format-docs
+format-docs:
+	$(FLOWMARK) --auto .
+```
+
+Passing `.` lets Flowmark discover files once and honor `.gitignore` and
+`.flowmarkignore` from the repository root.
+Avoid shell `find` pipelines or per-directory invocations unless the repository requires
+them.
+
+Start `.flowmarkignore` with content Flowmark must not rewrite:
+
+```gitignore
+# Generated or vendored Markdown
+docs/api/_generated/
+third_party/
+
+# Byte-exact fixtures and golden files
+tests/fixtures/
+tests/golden/
+```
+
+When documentation is generated, format canonical sources first, then regenerate their
+mirrors. Exclude generated mirrors from Flowmark so there is one source of truth.
+
+## Auto-Fix on Commit
+
+Lefthook can format and stage Markdown without turning style into a separate failure:
+
+```yaml
+pre-commit:
+  commands:
+    flowmark:
+      glob: "*.md"
+      run: uvx --from flowmark-rs==__FLOWMARK_RS_VERSION__ flowmark --auto --force-exclude {staged_files}
+      stage_fixed: true
+```
+
+`--force-exclude` applies `.flowmarkignore` even though the hook passes explicit file
+paths. If generated docs must be refreshed after formatting, call one repository script
+or Make target that performs both operations in the required order.
+
+For the `pre-commit` framework, use a local system hook with the same pinned command:
+
+```yaml
+repos:
+  - repo: local
+    hooks:
+      - id: flowmark
+        name: flowmark
+        entry: uvx --from flowmark-rs==__FLOWMARK_RS_VERSION__ flowmark --auto --force-exclude
+        language: system
+        types: [markdown]
+```
+
+The `pre-commit` framework stops the first commit after modifying files; stage the fixes
+and retry. Use Lefthook with `stage_fixed: true` when transparent auto-staging is
+preferred.
+
+## Disable Competing Markdown Formatters
+
+For Prettier, exclude Markdown in `.prettierignore`:
+
+```gitignore
+*.md
+```
+
+Also remove Markdown-specific Prettier hooks and editor defaults.
+If Flowmark owns MDX or another extension via `--extend-include`, exclude that extension
+from Prettier too.
+
+Apply the same ownership rule to other tools: keep them for code and data formats, but
+remove Markdown from their include globs and format-on-save configuration.
+Do not run two Markdown formatters sequentially; they can churn each other’s output and
+make hooks or CI nondeterministic.
+
+<!-- This document follows common-doc-guidelines.md.
+See github.com/jlevy/practical-prose and review guidelines before editing.
+-->

--- a/tests/test_skill.py
+++ b/tests/test_skill.py
@@ -108,6 +108,7 @@ class TestComposeSkill:
         # Routes to the self-documenting CLI.
         assert "flowmark --help" in content
         assert "flowmark --docs" in content
+        assert "same runner with `--install-skill`" in content
         # Does not duplicate the editor-setup recipe that --docs already covers.
         assert "emeraldwalk.runonsave" not in content
 
@@ -281,6 +282,17 @@ class TestInstallSkill:
         assert [r.action for r in results] == ["blocked-newer"]
         assert results[0].path == target
         assert target.read_text() == "<!-- format=f99 surface=skill-reference -->\nnewer"
+        assert not (skill_dir / "SKILL.md").exists()
+
+    def test_install_does_not_publish_skill_before_reference(self, tmp_path: Path) -> None:
+        skill_dir = tmp_path / ".claude" / "skills" / "flowmark"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "references").write_text("not a directory", encoding="utf-8")
+
+        with pytest.raises(SystemExit) as exc_info:
+            install_skill(project_root=tmp_path, surfaces=frozenset({SURFACE_CLAUDE}))
+
+        assert exc_info.value.code == 1
         assert not (skill_dir / "SKILL.md").exists()
 
 

--- a/tests/test_skill.py
+++ b/tests/test_skill.py
@@ -14,9 +14,11 @@ from flowmark.skill import (
     SURFACE_CLAUDE,
     SURFACE_PORTABLE,
     agents_md_block,
+    compose_project_setup,
     compose_skill,
     flowmark_version,
     get_docs_content,
+    get_project_setup_content,
     get_skill_content,
     install_skill,
     is_pypi_release,
@@ -45,6 +47,13 @@ class TestGetSkillContent:
         content = get_skill_content()
         assert "# Flowmark" in content
         assert "flowmark --auto" in content
+
+    def test_skill_routes_repository_adoption_to_bundled_reference(self) -> None:
+        content = get_skill_content()
+        assert "references/project-setup.md" in content
+        reference = get_project_setup_content()
+        assert "## Auto-Fix on Commit" in reference
+        assert "## Disable Competing Markdown Formatters" in reference
 
 
 class TestComposeSkill:
@@ -86,9 +95,15 @@ class TestComposeSkill:
         rendered = compose_skill("1.2.3")
         assert rendered.startswith("---\nname: flowmark\n")
 
+    def test_compose_project_setup_substitutes_rust_pin(self) -> None:
+        rendered = compose_project_setup("1.2.3")
+        assert "flowmark-rs==1.2.3" in rendered
+        assert "__FLOWMARK_RS_VERSION__" not in rendered
+
     def test_skill_routes_details_to_cli(self) -> None:
         """The skill stays minimal: it routes to the self-documenting CLI rather than
-        inlining setup details. Editor/project setup lives in `flowmark --docs`."""
+        inlining CLI mechanics. Editor setup lives in `flowmark --docs`; repository
+        migration lives in the bundled project-setup reference."""
         content = get_skill_content()
         # Routes to the self-documenting CLI.
         assert "flowmark --help" in content
@@ -183,14 +198,21 @@ class TestInstallSkill:
 
         portable = tmp_path / ".agents" / "skills" / "flowmark" / "SKILL.md"
         claude = tmp_path / ".claude" / "skills" / "flowmark" / "SKILL.md"
+        portable_reference = portable.parent / "references" / "project-setup.md"
+        claude_reference = claude.parent / "references" / "project-setup.md"
         assert portable.exists()
         assert claude.exists()
+        assert portable_reference.exists()
+        assert claude_reference.exists()
         assert "name: flowmark" in claude.read_text()
 
     def test_install_target_selection(self, tmp_path: Path) -> None:
         """The `surfaces` set selects which surfaces are written."""
         install_skill(project_root=tmp_path, surfaces=frozenset({SURFACE_PORTABLE}))
         assert (tmp_path / ".agents" / "skills" / "flowmark" / "SKILL.md").exists()
+        assert (
+            tmp_path / ".agents" / "skills" / "flowmark" / "references" / "project-setup.md"
+        ).exists()
         assert not (tmp_path / ".claude").exists()
         assert not (tmp_path / "AGENTS.md").exists()
 
@@ -198,9 +220,13 @@ class TestInstallSkill:
         install_skill(project_root=tmp_path)
         content = (tmp_path / ".claude" / "skills" / "flowmark" / "SKILL.md").read_text()
         assert "DO NOT EDIT" in content
-        assert "format=f02 surface=skill-md" in content
+        assert "format=f03 surface=skill-md" in content
         # Frontmatter must still come first for the skill to parse.
         assert content.startswith("---\nname: flowmark\n")
+        reference = (
+            tmp_path / ".claude" / "skills" / "flowmark" / "references" / "project-setup.md"
+        ).read_text()
+        assert "format=f03 surface=skill-reference" in reference
 
     def test_install_is_idempotent(self, tmp_path: Path) -> None:
         first = install_skill(project_root=tmp_path)
@@ -244,6 +270,18 @@ class TestInstallSkill:
         assert [r.action for r in results] == ["blocked-newer"]
         assert target.read_text() == "<!-- format=f99 surface=skill-md -->\nnewer"
 
+    def test_forward_compat_guard_checks_bundled_reference(self, tmp_path: Path) -> None:
+        skill_dir = tmp_path / ".claude" / "skills" / "flowmark"
+        target = skill_dir / "references" / "project-setup.md"
+        target.parent.mkdir(parents=True)
+        target.write_text("<!-- format=f99 surface=skill-reference -->\nnewer", encoding="utf-8")
+
+        results = install_skill(project_root=tmp_path, surfaces=frozenset({SURFACE_CLAUDE}))
+
+        assert [r.action for r in results] == ["blocked-newer"]
+        assert target.read_text() == "<!-- format=f99 surface=skill-reference -->\nnewer"
+        assert not (skill_dir / "SKILL.md").exists()
+
 
 class TestAgentsMdBlock:
     """Tests for the AGENTS.md integration block."""
@@ -251,7 +289,7 @@ class TestAgentsMdBlock:
     def test_block_is_marker_bounded_with_format(self) -> None:
         block = agents_md_block("1.2.3")
         assert block.startswith(AGENTS_BEGIN_PREFIX)
-        assert "format=f02" in block
+        assert "format=f03" in block
         assert block.rstrip().endswith(AGENTS_END_MARKER)
         assert "flowmark==1.2.3" in block
 
@@ -325,6 +363,7 @@ class TestAgentsMdBlock:
 
         skill_file = custom_base / "skills" / "flowmark" / "SKILL.md"
         assert skill_file.exists()
+        assert (skill_file.parent / "references" / "project-setup.md").exists()
 
         content = skill_file.read_text()
         assert "name: flowmark" in content
@@ -337,6 +376,7 @@ class TestAgentsMdBlock:
 
         skill_file = custom_base / "skills" / "flowmark" / "SKILL.md"
         assert skill_file.exists()
+        assert (skill_file.parent / "references" / "project-setup.md").exists()
 
     def test_install_skill_overwrites_existing(self, tmp_path: Path) -> None:
         """Skill installation overwrites existing SKILL.md."""

--- a/tests/test_skill.py
+++ b/tests/test_skill.py
@@ -279,6 +279,7 @@ class TestInstallSkill:
         results = install_skill(project_root=tmp_path, surfaces=frozenset({SURFACE_CLAUDE}))
 
         assert [r.action for r in results] == ["blocked-newer"]
+        assert results[0].path == target
         assert target.read_text() == "<!-- format=f99 surface=skill-reference -->\nnewer"
         assert not (skill_dir / "SKILL.md").exists()
 

--- a/tests/test_skill_artifacts.py
+++ b/tests/test_skill_artifacts.py
@@ -76,6 +76,14 @@ def test_discovery_skill_bundles_its_project_setup_reference() -> None:
     assert DISCOVERY_REFERENCE.is_file()
 
 
+def test_readme_uses_main_repository_for_skill_distribution() -> None:
+    """The Python repository is the sole public discovery and documentation source."""
+    text = README.read_text(encoding="utf-8")
+    assert "npx skills add jlevy/flowmark@flowmark" in text
+    assert "jlevy/flowmark-rs@flowmark" not in text
+    assert "github.com/jlevy/flowmark/blob/main/skills/flowmark/SKILL.md" in text
+
+
 def test_project_setup_hooks_cover_common_markdown_extensions() -> None:
     reference = DISCOVERY_REFERENCE.read_text(encoding="utf-8")
     assert 'glob: "*.{md,mdc,markdown}"' in reference

--- a/tests/test_skill_artifacts.py
+++ b/tests/test_skill_artifacts.py
@@ -11,12 +11,14 @@ from flowmark.skill import (
     DISCOVERY_VERSION,
     FLOWMARK_RS_DISCOVERY_VERSION,
     compose_skill,
+    discovery_project_setup_text,
     discovery_skill_text,
     is_pypi_release,
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DISCOVERY_COPY = REPO_ROOT / "skills" / "flowmark" / "SKILL.md"
+DISCOVERY_REFERENCE = REPO_ROOT / "skills" / "flowmark" / "references" / "project-setup.md"
 README = REPO_ROOT / "README.md"
 
 # Artifacts whose runner-pin examples are consumed by users/agents and must all pin the
@@ -33,12 +35,16 @@ _PINNED_ARTIFACTS = [
     REPO_ROOT / "AGENTS.md",
 ]
 
-# Skill surfaces that also carry a recommended Rust-port `flowmark-rs==` pin (the README
-# references flowmark-rs without an exact pin, so it is excluded here).
+# Shipped docs and skill resources that carry the recommended Rust-port
+# `flowmark-rs==` pin.
 _RS_PINNED_ARTIFACTS = [
+    README,
     DISCOVERY_COPY,
+    DISCOVERY_REFERENCE,
     REPO_ROOT / ".agents" / "skills" / "flowmark" / "SKILL.md",
+    REPO_ROOT / ".agents" / "skills" / "flowmark" / "references" / "project-setup.md",
     REPO_ROOT / ".claude" / "skills" / "flowmark" / "SKILL.md",
+    REPO_ROOT / ".claude" / "skills" / "flowmark" / "references" / "project-setup.md",
     REPO_ROOT / "AGENTS.md",
 ]
 
@@ -53,12 +59,21 @@ _CONCRETE_RS_PIN_RE = re.compile(r"flowmark-rs==(\d[^\s`)\"']*)")
 def test_discovery_copy_matches_generator() -> None:
     """The committed repo-root discovery copy must match the generator output."""
     assert DISCOVERY_COPY.read_text(encoding="utf-8") == discovery_skill_text()
+    assert DISCOVERY_REFERENCE.read_text(encoding="utf-8") == discovery_project_setup_text()
 
 
 def test_discovery_copy_is_flowmark_stable() -> None:
     """`flowmark --auto` over the discovery copy must be a no-op (it lives under `skills/`)."""
     text = DISCOVERY_COPY.read_text(encoding="utf-8")
     assert reformat_text(text) == text
+    reference = DISCOVERY_REFERENCE.read_text(encoding="utf-8")
+    assert reformat_text(reference) == reference
+
+
+def test_discovery_skill_bundles_its_project_setup_reference() -> None:
+    text = DISCOVERY_COPY.read_text(encoding="utf-8")
+    assert "references/project-setup.md" in text
+    assert DISCOVERY_REFERENCE.is_file()
 
 
 @pytest.mark.parametrize("artifact", _PINNED_ARTIFACTS, ids=lambda p: p.name)
@@ -120,7 +135,7 @@ def test_shipped_artifacts_never_use_at_latest(artifact: Path) -> None:
 def test_discovery_copy_has_resolvable_version_pin() -> None:
     """The committed discovery copy must pin a real, PyPI-installable version.
 
-    `npx skills add jlevy/flowmark` users have no other source of truth for the
+    `npx skills add jlevy/flowmark@flowmark` users have no other source of truth for the
     bootstrap invocation, so a `<version>` placeholder or `.dev`/local-suffix pin
     in the committed copy would silently break the cross-agent install promise in
     the README.

--- a/tests/test_skill_artifacts.py
+++ b/tests/test_skill_artifacts.py
@@ -76,6 +76,12 @@ def test_discovery_skill_bundles_its_project_setup_reference() -> None:
     assert DISCOVERY_REFERENCE.is_file()
 
 
+def test_project_setup_hooks_cover_common_markdown_extensions() -> None:
+    reference = DISCOVERY_REFERENCE.read_text(encoding="utf-8")
+    assert 'glob: "*.{md,mdc,markdown}"' in reference
+    assert "files: '\\.(md|mdc|markdown)$'" in reference
+
+
 @pytest.mark.parametrize("artifact", _PINNED_ARTIFACTS, ids=lambda p: p.name)
 def test_shipped_artifacts_pin_discovery_version(artifact: Path) -> None:
     """Every concrete `flowmark==` pin in a shipped artifact equals DISCOVERY_VERSION.

--- a/tests/tryscript/cli-golden.tryscript.md
+++ b/tests/tryscript/cli-golden.tryscript.md
@@ -14,11 +14,10 @@ before: |
   printf '# Also excluded\n' > project/.venv/lib/README.md
   printf 'not markdown\n' > project/code.py
 ---
-
 # Flowmark CLI Golden Tests
 
-End-to-end tests for the Flowmark CLI, covering formatting, file discovery,
-error handling, and agent skills.
+End-to-end tests for the Flowmark CLI, covering formatting, file discovery, error
+handling, and agent skills.
 
 ## Version
 
@@ -139,7 +138,7 @@ $ printf 'drafts/\n' > project/.flowmarkignore && flowmark --list-files project 
 $ flowmark --skill | head -3
 ---
 name: flowmark
-description: Fast, consistent Markdown auto-formatter for typographic cleanup (smart quotes, ellipses), normalized formatting, and optional clean line wrapping for small, readable git diffs. Use when creating, editing, or normalizing Markdown (.md) files, cleaning up LLM-generated Markdown, or when the user mentions flowmark or formatting Markdown.
+description: Fast, consistent Markdown auto-formatter for typographic cleanup, normalization, and clean semantic line breaks. Use when creating, editing, or cleaning Markdown; formatting LLM-generated docs; adopting Flowmark in a repository; adding Markdown format scripts or commit hooks; or replacing Prettier or another Markdown formatter.
 ```
 
 ## Docs: print documentation

--- a/tests/tryscript/verbose-docs.tryscript.md
+++ b/tests/tryscript/verbose-docs.tryscript.md
@@ -8,7 +8,6 @@ path:
 before: |
   cp -r $TRYSCRIPT_TEST_DIR/fixtures/. fixtures/
 ---
-
 # Verbose, Docs, and Skill Tests
 
 Tests for --skill, --install-skill, and --docs output.
@@ -21,7 +20,7 @@ behavior.
 $ flowmark --skill | sed -n '1,6p'
 ---
 name: flowmark
-description: Fast, consistent Markdown auto-formatter for typographic cleanup (smart quotes, ellipses), normalized formatting, and optional clean line wrapping for small, readable git diffs. Use when creating, editing, or normalizing Markdown (.md) files, cleaning up LLM-generated Markdown, or when the user mentions flowmark or formatting Markdown.
+description: Fast, consistent Markdown auto-formatter for typographic cleanup, normalization, and clean semantic line breaks. Use when creating, editing, or cleaning Markdown; formatting LLM-generated docs; adopting Flowmark in a repository; adding Markdown format scripts or commit hooks; or replacing Prettier or another Markdown formatter.
 allowed-tools: Bash(flowmark:*), Bash(uvx:*), Read, Write
 ---
 # Flowmark - Markdown Auto-Formatter
@@ -57,7 +56,7 @@ nested dirs created
 
 ```console
 $ flowmark --skill | grep -F -- "the full guide:" | sed 's/^- //'
-`flowmark --docs` — the full guide: editor on-save setup (VS Code/Cursor), project
+`flowmark --docs` — the full guide: configuration, file discovery, editor setup, the
 ```
 
 ## V6: Install skill project-local default writes all three surfaces


### PR DESCRIPTION
## Summary

- publish the sole public `flowmark` skill bundle and documentation source, installable as `npx skills add jlevy/flowmark@flowmark`
- keep flowmark-rs as the recommended implementation with a byte-identical runtime mirror for CLI parity
- prefer the pinned Rust runner for one-file and whole-repository formatting
- bundle concise migration guidance for Makefiles, `.flowmarkignore`, auto-fixing commit hooks, CI policy, and disabling competing Markdown formatters
- install and drift-check the complete bundle across portable and Claude skill surfaces

## Validation

- 463 Python tests and 133 tryscript golden cases
- ruff, basedpyright, codespell, and golden coverage checks
- Agent Skills validators and a real local `npx skills add` installation
- built wheel contains both skill resources

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly generated docs, skill install artifacts, and pin consistency; install logic is extended but covered by drift and unit tests with no security or data-path impact.
> 
> **Overview**
> **Expands the cross-agent Flowmark skill** from a single `SKILL.md` into a **format `f03` bundle** that installs and publishes **`references/project-setup.md`** alongside the skill on portable, Claude, and discovery surfaces (`skills/flowmark/`).
> 
> The skill text is reorganized around **formatting** vs **repository adoption**, prefers a **pinned `flowmark-rs==0.3.1`** `uvx` runner (Python pin unchanged at `0.7.2`), and points migration detail at the new reference instead of inlining it in README/skill. Public install is documented as **`npx skills add jlevy/flowmark@flowmark`**.
> 
> **`skill.py` and generators** now compose/install/drift-check both files, bump **`FLOWMARK_FORMAT`**, extend forward-compat guards to the reference, and **`generate-python-readme.py`** substitutes both **`__FLOWMARK_VERSION__`** and **`__FLOWMARK_RS_VERSION__`**. README/shared docs **replace the long “Recommended Project Setup” section** with a short Rust command plus a link to the bundled migration doc.
> 
> **CI/Makefile** pin **`skills-ref@0.1.5`** for skill validation; tests and tryscript goldens updated for the new description, docs routing, and bundle behavior. **`.tbd/config.yml`** is refreshed (format `f06`, expanded docs cache) as tooling sync, not Flowmark runtime logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adec5f5a11eeda48c1eb48094df6fc3b997ffdb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->