### PR TITLE
docs: quote ${file} in the Run on Save snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,11 +517,15 @@ Then add to your `settings.json`:
     "commands": [
         {
             "match": "(\\.md|\\.md\\.jinja|\\.mdc)$",
-            "cmd": "flowmark --auto ${file}"
+            "cmd": "flowmark --auto \"${file}\""
         }
     ]
   }
 ```
+
+The quotes around `${file}` matter: the command runs through a shell, so an unquoted
+path containing spaces splits into multiple arguments and the save silently skips
+formatting.
 
 The `--auto` option is just the same as
 `--inplace --nobackup --semantic --cleanups --smartquotes --ellipses`.

--- a/docs/shared/flowmark-readme-shared.md
+++ b/docs/shared/flowmark-readme-shared.md
@@ -505,11 +505,15 @@ Then add to your `settings.json`:
     "commands": [
         {
             "match": "(\\.md|\\.md\\.jinja|\\.mdc)$",
-            "cmd": "flowmark --auto ${file}"
+            "cmd": "flowmark --auto \"${file}\""
         }
     ]
   }
 ```
+
+The quotes around `${file}` matter: the command runs through a shell, so an unquoted
+path containing spaces splits into multiple arguments and the save silently skips
+formatting.
 
 The `--auto` option is just the same as
 `--inplace --nobackup --semantic --cleanups --smartquotes --ellipses`.


### PR DESCRIPTION
The README's VSCode/Cursor "Run on Save" snippet passes `${file}` to the shell unquoted. For any Markdown file whose path contains a space, the path splits into multiple arguments, `flowmark --auto` fails with `Path not found`, and the failure is invisible unless you open the Run On Save output channel — save appears to work but the file is never formatted.

This quotes the variable in the canonical shared docs body (`docs/shared/flowmark-readme-shared.md`), adds a one-sentence note explaining why the quotes matter, and regenerates `README.md` via `make generate-readme` + the repo flowmark format pass.

Found in practice: a repo directory named `trading research/` meant cmd-s formatted every Markdown file except the ones in that tree.

The same snippet in the flowmark-rs README comes from this shared doc via the `repos/flowmark` submodule (CI `readme-sync` gate), so it picks up the fix on the next submodule bump after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to README and shared docs; no runtime or formatting logic is modified.
> 
> **Overview**
> Fixes the VSCode/Cursor **Run on Save** example so `flowmark --auto` receives a single file path when `${file}` contains spaces.
> 
> The canonical snippet in `docs/shared/flowmark-readme-shared.md` now uses `"cmd": "flowmark --auto \"${file}\""` instead of an unquoted `${file}`, and a short note explains that the extension runs the command through a shell—without quotes, paths with spaces split into multiple arguments, formatting fails quietly on save, and `README.md` is regenerated from the shared doc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca7c599cefc3620cdc51f912dca0059cd020356d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->